### PR TITLE
Use udp at 14550, because the previous tcp isnt acessible from within the docker network

### DIFF
--- a/README_DEVS.md
+++ b/README_DEVS.md
@@ -58,7 +58,7 @@ There are a few options:
     "--verbose",
     "--web-server", "0.0.0.0:8080",
     "--mcm-address", "blueos.internal:6020",
-    "--mavlink", "tcpout:blueos.internal:5777",
+    "--mavlink", "udpout:blueos.internal:14550",
     "--mavlink-system-id", "1",
     "--mavlink-component-id", "56",
     "--log-path", "/logs",

--- a/dockerfile
+++ b/dockerfile
@@ -39,7 +39,7 @@ ENTRYPOINT [ \
     "./radcam-manager", \
     "--web-server", "0.0.0.0:8080", \
     "--mcm-address", "blueos.internal:6020", \
-    "--mavlink", "tcpout:blueos.internal:5777", \
+    "--mavlink", "udpout:blueos.internal:14550", \
     "--mavlink-system-id", "1", \
     "--mavlink-component-id", "56", \
     "--log-path", "/logs", \


### PR DESCRIPTION
The extension was failing to work with mavlink-server because the endpoint 5777 is limited to 127.0.0.1, and the extension runs inside a Docker network, so it is not localhost and can't reach it. For now, I opted to use the GCS endpoint (udp server at 14550).

Closes #62