### PR TITLE
backend: libs: radcam_manager: src: web: routes: v1: Add missing hashtag to the iframe URL

### DIFF
--- a/backend/libs/radcam_manager/src/web/routes/v1/cockpit.rs
+++ b/backend/libs/radcam_manager/src/web/routes/v1/cockpit.rs
@@ -82,7 +82,7 @@ fn widgets(cameras: &Cameras) -> Vec<CockpitWidget> {
         .map(|(camera_uuid, camera)| CockpitWidget {
             name: format!("RadCam ({})", camera.hostname),
             config_iframe_url: None,
-            iframe_url: format!("/?uuid={camera_uuid}&cockpit_mode=true"),
+            iframe_url: format!("#/?uuid={camera_uuid}&cockpit_mode=true"),
             iframe_icon: "/assets/logo.svg".to_string(),
             version: version.clone(),
         })


### PR DESCRIPTION
After, it effectively gets the transparency from Cockpit style:

<img width="484" height="305" alt="image" src="https://github.com/user-attachments/assets/c142d842-b201-4311-8fc3-68a91c2b7afa" />
