### PR TITLE
backend: bin: Fix .git path

### DIFF
--- a/backend/bin/build.rs
+++ b/backend/bin/build.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn generate_build_details() -> Result<(), Box<dyn std::error::Error>> {
-    if std::path::Path::new("../.git").is_dir() {
+    if std::path::Path::new("../../.git").is_dir() {
         vergen_gix::Emitter::default()
             .add_instructions(&BuildBuilder::all_build()?)?
             .add_instructions(&GixBuilder::all_git()?)?


### PR DESCRIPTION
Vergen was not emitting info because we were skipping it because we were looking at the wrong .git path.