### PR TITLE
Reorganize UI

### DIFF
--- a/frontend/src/components/BasicSettings.vue
+++ b/frontend/src/components/BasicSettings.vue
@@ -92,7 +92,7 @@
             theme="dark"
             @update:model-value="updateActuatorsConfig('enable_focus_and_zoom_correlation', $event)"
           />
-          <BlueSlider
+          <!-- <BlueSlider
             v-model="focusOffsetUI"
             :disabled="!isConfigured || props.disabled"
             name="focus-offset"
@@ -104,7 +104,7 @@
             theme="dark"
             class="mt-6"
             @update:model-value="onFocusOffsetChange($event ?? 0)"
-          />
+          /> -->
         </div>
       </ExpansiblePanel>
     </ExpansiblePanel>


### PR DESCRIPTION
- Moves focus/zoom configs to inside Actuators because it is less important
- Hides Focus compensation because it wasn't implemented
- Moves Video panel down because it is less important


<img width="734" height="744" alt="image" src="https://github.com/user-attachments/assets/1d19aac8-74aa-43f5-b7a7-1e97d3c13e56" />
