### PR TITLE
backend: libs: autopilot: src: api: Fix swapped endpoint renaming

### DIFF
--- a/backend/libs/autopilot/src/api.rs
+++ b/backend/libs/autopilot/src/api.rs
@@ -21,9 +21,9 @@ pub enum Action {
     GetActuatorsState,
     #[serde(rename = "setActuatorsState")]
     SetActuatorsState(ActuatorsState),
-    #[serde(rename = "getActuatorsConfig")]
-    GetActuatorsDefaultConfig,
     #[serde(rename = "getActuatorsDefaultConfig")]
+    GetActuatorsDefaultConfig,
+    #[serde(rename = "getActuatorsConfig")]
     GetActuatorsConfig,
     #[serde(rename = "setActuatorsConfig")]
     SetActuatorsConfig(ActuatorsConfig),


### PR DESCRIPTION
embarrassing :sob: 