### PR TITLE
radcam_commands: src: Add device-agnostic white balance action

### DIFF
--- a/backend/libs/radcam_commands/src/mod.rs
+++ b/backend/libs/radcam_commands/src/mod.rs
@@ -19,6 +19,7 @@ pub mod protocol;
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 // #[tsync] // FIXME: Disabled for now, see https://github.com/Wulf/tsync/issues/58
 pub struct CameraControl {
+    #[serde(default)]
     #[ts(as = "String")]
     pub camera_uuid: Uuid,
     #[serde(flatten)]
@@ -41,6 +42,9 @@ pub enum Action {
     SetImageAdjustment(BaseParameterSetting),
     #[serde(rename = "setImageAdjustmentEx")]
     SetImageAdjustmentEx(AdvancedParameterSetting),
+    /// Important: This is a wrapper, not part of the camera protocol
+    #[serde(rename = "setImageAdjustmentExAll")]
+    SetImageAdjustmentExAll(AdvancedParameterSetting),
     #[serde(rename = "setVencConf")]
     SetVideoParameterSettings(VideoParameterSettings),
     #[serde(rename = "restart")]
@@ -67,6 +71,9 @@ fn control_inner(
         match &camera_control.action {
             Action::SetRecommendedSettings => {
                 return apply_recommended_settings(camera_control.camera_uuid).await;
+            }
+            Action::SetImageAdjustmentExAll(params) => {
+                return apply_set_image_adjustment_ex_all(params).await;
             }
             _ => (),
         }
@@ -164,6 +171,33 @@ pub async fn list() -> impl IntoResponse {
     };
 
     json.into_response()
+}
+
+#[instrument(level = "debug")]
+async fn apply_set_image_adjustment_ex_all(
+    params: &AdvancedParameterSetting,
+) -> Result<serde_json::Value> {
+    let cameras = mcm_client::cameras().await;
+    let mut errors = vec![];
+
+    for (camera_uuid, camera) in &cameras {
+        let camera_control = CameraControl {
+            camera_uuid: *camera_uuid,
+            action: Action::SetImageAdjustmentEx(params.clone()),
+        };
+
+        if let Err(error) = control_inner(Json(camera_control)).await {
+            let message = format!("{}: {error:?}", camera.hostname);
+            error!(message);
+            errors.push(message);
+        }
+    }
+
+    match errors.len() {
+        0 => Ok(serde_json::Value::Null),
+        1 => Err(anyhow::anyhow!("{}", errors[0])),
+        _ => Err(anyhow::anyhow!("Multiple errors happened: {errors:?}")),
+    }
 }
 
 #[instrument(level = "debug")]

--- a/backend/libs/radcam_manager/src/web/routes/v1/cockpit.rs
+++ b/backend/libs/radcam_manager/src/web/routes/v1/cockpit.rs
@@ -171,7 +171,7 @@ fn widgets(cameras: &Cameras) -> Vec<CockpitIframeWidget> {
 }
 
 fn actions(cameras: &Cameras) -> Vec<CockpitAction> {
-    cameras
+    let mut actions = cameras
         .iter()
         .flat_map(|(camera_uuid, camera)| {
             let name: String = format!("RadCam One-Push White Balance ({})", camera.hostname);
@@ -202,10 +202,35 @@ fn actions(cameras: &Cameras) -> Vec<CockpitAction> {
                 version: env!("CARGO_PKG_VERSION").to_string(), // TODO: freeze this once we settle with a button layout
             }]
         })
-        .collect()
+        .collect::<Vec<CockpitAction>>();
+
+    actions.insert(
+        0,
+        CockpitAction {
+            id: "radcam_white_balance_all".to_string(),
+            name: "RadCam One-Push White Balance (All)".to_string(),
+            action_type: CockpitActionType::HttpRequest(HttpRequestAction {
+                name: "RadCam One-Push White Balance (All)".to_string(),
+                url: "http://{{ vehicle-address }}/extensionv2/radcammanager/v1/camera/control"
+                    .to_string(),
+                method: HttpRequestMethod::POST,
+                headers: json!({
+                    "Content-Type": "application/json",
+                }),
+                url_params: json!({}),
+                body: json!({
+                    "action": "setImageAdjustmentExAll",
+                    "json": { "onceAWB": 1 },
+                })
+                .to_string(),
+            }),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+        },
+    );
+    actions
 }
 
-fn joystick_suggestions(cameras: &Cameras) -> Vec<JoystickMapSuggestion> {
+fn joystick_suggestions(_cameras: &Cameras) -> Vec<JoystickMapSuggestion> {
     let mut mappings_rov = vec![
         // === Regular modifier ===
         ButtonMappingSuggestion {
@@ -413,7 +438,7 @@ fn joystick_suggestions(cameras: &Cameras) -> Vec<JoystickMapSuggestion> {
         },
     ]);
 
-    let mut mappings_for_anys = vec![
+    let mappings_for_anys = vec![
         ButtonMappingSuggestion {
             id: "camera-zoom-decrease".to_string(),
             action_protocol: JoystickProtocol::DataLakeVariable,
@@ -459,19 +484,16 @@ fn joystick_suggestions(cameras: &Cameras) -> Vec<JoystickMapSuggestion> {
             modifier_key: CockpitModifierKeyOption::Regular,
             description: Some("Toggle recording all streams".to_string()),
         },
-    ];
-
-    for (camera_uuid, _camera) in cameras {
-        mappings_for_anys.push(ButtonMappingSuggestion {
-            id: format!("radcam_white_balance_{camera_uuid}"),
+        ButtonMappingSuggestion {
+            id: "radcam_white_balance_all".to_string(),
             action_protocol: JoystickProtocol::CockpitAction,
-            action_name: format!("RadCam One-Push White Balance ({})", _camera.hostname),
-            action_id: format!("radcam_white_balance_{camera_uuid}"),
+            action_name: "RadCam One-Push White Balance (All)".to_string(),
+            action_id: "radcam_white_balance_all".to_string(),
             button: 10,
             modifier_key: CockpitModifierKeyOption::Regular,
-            description: Some("Run One-Push White Balance once".to_string()),
-        })
-    }
+            description: Some("Run One-Push White Balance on all RadCam devices".to_string()),
+        },
+    ];
 
     mappings_rov.extend_from_slice(&mappings_for_anys);
     mappings_rov_with_gripper.extend_from_slice(&mappings_for_anys);


### PR DESCRIPTION
Closes #189 

To test it, past the following in a new BlueOS Extension:
```
{  "identifier": "joaoantoniocardoso.radcam-manager",  "name": "RadCam Manager (DEV)",  "docker": "joaoantoniocardoso/blueos-radcam-manager",  "tag": "add_device_agnostic_white_balance",  "permissions": "{\"ExposedPorts\":{\"8080/tcp\":{}},\"HostConfig\":{\"Binds\":[\"/var/logs/blueos/extensions/radcam-manager:/logs\",\"/usr/blueos/extensions/radcam-manager:/app\",\"/root/.config/blueos/ardupilot-manager/firmware/scripts:/scripts\"],\"ExtraHosts\":[\"blueos.internal:host-gateway\"],\"PortBindings\":{\"8080/tcp\":[{\"HostPort\":\"\"}]}}}"}
```