### PR TITLE
websockets 02/24: Demand-gated SERVO watch and autopilot handle_control

### DIFF
--- a/backend/bin/src/main.rs
+++ b/backend/bin/src/main.rs
@@ -79,6 +79,7 @@ async fn start_application(first_start: bool) -> Result<bool> {
     autopilot_startup_task.abort();
     mcm_client_startup_task.abort();
     mcm_client::shutdown().await;
+    autopilot::shutdown_actuators_stream().await;
 
     if shutdown_reason == ShutdownReason::Signal {
         return Ok(false);

--- a/backend/libs/autopilot/src/actuators_watch.rs
+++ b/backend/libs/autopilot/src/actuators_watch.rs
@@ -1,0 +1,399 @@
+use std::{
+    collections::HashMap,
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    time::{Duration, Instant},
+};
+
+use mavlink::{
+    Message as _, MessageData,
+    ardupilotmega::{MavMessage, SERVO_OUTPUT_RAW_DATA},
+};
+use once_cell::sync::OnceCell;
+use tokio::sync::{Notify, broadcast};
+use tracing::*;
+use uuid::Uuid;
+
+use crate::{
+    api,
+    manager::{self, MANAGER},
+    mavlink::Message,
+};
+
+const MIN_EMIT_INTERVAL: Duration = Duration::from_millis(100);
+/// Requesting the stream faster than the UI emit gating would only waste bandwidth.
+const SERVO_STREAM_INTERVAL_US: f32 = MIN_EMIT_INTERVAL.as_micros() as f32;
+/// `MAV_CMD_SET_MESSAGE_INTERVAL` disables a stream when given a negative interval.
+const STREAM_DISABLED_INTERVAL_US: f32 = -1.0;
+const STREAM_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
+const STREAM_STALE_AFTER: Duration = Duration::from_secs(3);
+const RECEIVER_REOPEN_BACKOFF: Duration = Duration::from_secs(1);
+/// Bound SERVO interval requests so an unresponsive autopilot cannot stall the watcher.
+const SERVO_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+
+static STATE_TX: OnceCell<broadcast::Sender<ActuatorsStateUpdate>> = OnceCell::new();
+static WATCHER_STARTED: AtomicBool = AtomicBool::new(false);
+static INTEREST: AtomicUsize = AtomicUsize::new(0);
+static INTEREST_CHANGED: Notify = Notify::const_new();
+
+/// Actuator positions derived from a MAVLink `SERVO_OUTPUT_RAW` sample.
+#[derive(Debug, Clone)]
+pub struct ActuatorsStateUpdate {
+    /// Camera whose actuators changed.
+    pub camera_uuid: Uuid,
+    /// Latest focus/zoom/tilt percentages.
+    pub state: api::ActuatorsState,
+}
+
+struct EmitGate {
+    last_emitted: HashMap<Uuid, api::ActuatorsState>,
+    last_emit_at: HashMap<Uuid, Instant>,
+    pending: HashMap<Uuid, api::ActuatorsState>,
+}
+
+impl EmitGate {
+    #[instrument(level = "debug", skip_all, fields(%camera_uuid))]
+    fn try_emit(
+        &mut self,
+        camera_uuid: Uuid,
+        state: api::ActuatorsState,
+        sender: &broadcast::Sender<ActuatorsStateUpdate>,
+    ) {
+        if self.last_emitted.get(&camera_uuid) == Some(&state) {
+            self.pending.remove(&camera_uuid);
+            return;
+        }
+
+        let now = Instant::now();
+        if let Some(last_emit) = self.last_emit_at.get(&camera_uuid)
+            && now.duration_since(*last_emit) < MIN_EMIT_INTERVAL
+        {
+            self.pending.insert(camera_uuid, state);
+            return;
+        }
+
+        self.emit(camera_uuid, state, sender, now);
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    fn flush_pending(&mut self, sender: &broadcast::Sender<ActuatorsStateUpdate>) {
+        let now = Instant::now();
+        let pending: Vec<(Uuid, api::ActuatorsState)> = self.pending.drain().collect();
+
+        for (camera_uuid, state) in pending {
+            if self.last_emitted.get(&camera_uuid) == Some(&state) {
+                continue;
+            }
+
+            let Some(last_emit) = self.last_emit_at.get(&camera_uuid) else {
+                self.emit(camera_uuid, state, sender, now);
+                continue;
+            };
+
+            if now.duration_since(*last_emit) >= MIN_EMIT_INTERVAL {
+                self.emit(camera_uuid, state, sender, now);
+            } else {
+                self.pending.insert(camera_uuid, state);
+            }
+        }
+    }
+
+    #[instrument(level = "debug", skip_all, fields(%camera_uuid))]
+    fn emit(
+        &mut self,
+        camera_uuid: Uuid,
+        state: api::ActuatorsState,
+        sender: &broadcast::Sender<ActuatorsStateUpdate>,
+        now: Instant,
+    ) {
+        // Ignore lag when nobody is listening yet.
+        if sender
+            .send(ActuatorsStateUpdate { camera_uuid, state })
+            .is_err()
+        {
+            debug!("No actuators state subscribers");
+        }
+        self.last_emitted.insert(camera_uuid, state);
+        self.last_emit_at.insert(camera_uuid, now);
+        self.pending.remove(&camera_uuid);
+    }
+}
+
+/// Subscribe to throttled actuator state updates from the SERVO stream.
+pub fn subscribe() -> broadcast::Receiver<ActuatorsStateUpdate> {
+    state_sender().subscribe()
+}
+
+/// Start the background SERVO_OUTPUT_RAW watcher once.
+///
+/// The watcher stays idle until [`add_interest`] is called: no high-rate stream
+/// is requested from the autopilot while there are no interested consumers.
+pub fn start() {
+    if WATCHER_STARTED
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return;
+    }
+
+    tokio::spawn(actuators_watcher());
+}
+
+/// Register interest in the SERVO stream, requesting it when the first one arrives.
+///
+/// Every call must be paired with a [`remove_interest`] call.
+#[instrument(level = "debug")]
+pub fn add_interest() {
+    if INTEREST.fetch_add(1, Ordering::SeqCst) == 0 {
+        INTEREST_CHANGED.notify_one();
+    }
+}
+
+/// Release an interest registered with [`add_interest`], disabling the SERVO
+/// stream when the last one is gone.
+#[instrument(level = "debug")]
+pub fn remove_interest() {
+    match INTEREST.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |interests| {
+        interests.checked_sub(1)
+    }) {
+        Ok(1) => INTEREST_CHANGED.notify_one(),
+        Ok(_) => (),
+        Err(_current) => warn!("Unbalanced remove_interest call, no interest registered"),
+    }
+}
+
+/// Disable the high-rate SERVO stream before process exit.
+///
+/// Safe to call with outstanding interest; clears the interest count and asks the
+/// autopilot to stop streaming `SERVO_OUTPUT_RAW`. Bounded so an unreachable
+/// autopilot cannot stall process exit for the full MAVLink ACK retry budget.
+#[instrument(level = "debug")]
+pub async fn shutdown() {
+    INTEREST.store(0, Ordering::SeqCst);
+    INTEREST_CHANGED.notify_waiters();
+    if tokio::time::timeout(
+        SERVO_REQUEST_TIMEOUT,
+        request_servo_stream(STREAM_DISABLED_INTERVAL_US),
+    )
+    .await
+    .is_err()
+    {
+        warn!("Timed out disabling SERVO_OUTPUT_RAW during shutdown");
+    }
+}
+
+fn state_sender() -> &'static broadcast::Sender<ActuatorsStateUpdate> {
+    STATE_TX.get_or_init(|| {
+        let (sender, _) = broadcast::channel(64);
+        sender
+    })
+}
+
+#[instrument(level = "debug", skip_all)]
+async fn actuators_watcher() {
+    let sender = state_sender().clone();
+
+    let mut gate = EmitGate {
+        last_emitted: HashMap::new(),
+        last_emit_at: HashMap::new(),
+        pending: HashMap::new(),
+    };
+
+    let mut refresh = tokio::time::interval(STREAM_REFRESH_INTERVAL);
+    refresh.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let mut last_servo_at = Instant::now();
+
+    loop {
+        let (mut receiver, target_system) = match open_receiver().await {
+            Some(pair) => pair,
+            None => {
+                tokio::time::sleep(STREAM_REFRESH_INTERVAL).await;
+                continue;
+            }
+        };
+
+        if INTEREST.load(Ordering::SeqCst) > 0 {
+            // Best-effort; refresh tick retries if the autopilot is quiet.
+            let _ = tokio::time::timeout(
+                SERVO_REQUEST_TIMEOUT,
+                request_servo_stream(SERVO_STREAM_INTERVAL_US),
+            )
+            .await;
+        }
+
+        loop {
+            tokio::select! {
+                message = receiver.recv() => {
+                    match message {
+                        Ok(Message::Received((header, message)))
+                            if header.system_id == target_system
+                                && header.component_id
+                                    == mavlink::ardupilotmega::MavComponent::MAV_COMP_ID_AUTOPILOT1 as u8
+                                && message.message_id() == SERVO_OUTPUT_RAW_DATA::ID =>
+                        {
+                            let MavMessage::SERVO_OUTPUT_RAW(servo_output_raw) = message else {
+                                continue;
+                            };
+
+                            if servo_output_raw.port != 0 {
+                                continue;
+                            }
+
+                            last_servo_at = Instant::now();
+
+                            let Some(manager) = MANAGER.get() else {
+                                continue;
+                            };
+
+                            let mut manager = manager.write().await;
+                            for (camera_uuid, actuators) in &mut manager.settings.actuators {
+                                let state =
+                                    manager::actuators_state_from_servo(actuators, &servo_output_raw);
+                                actuators.state = state;
+                                gate.try_emit(*camera_uuid, state, &sender);
+                            }
+                            drop(manager);
+
+                            gate.flush_pending(&sender);
+                        }
+                        Ok(_) => continue,
+                        Err(broadcast::error::RecvError::Closed) => {
+                            debug!("MAVLink receiver closed; reopening actuators watcher");
+                            tokio::time::sleep(RECEIVER_REOPEN_BACKOFF).await;
+                            break;
+                        }
+                        Err(broadcast::error::RecvError::Lagged(samples)) => {
+                            debug!("Actuators watcher lagged by {samples} MAVLink messages");
+                        }
+                    }
+                }
+                _ = refresh.tick() => {
+                    // Flush throttle-stranded samples even when SERVO goes quiet.
+                    gate.flush_pending(&sender);
+                    if INTEREST.load(Ordering::SeqCst) > 0 && last_servo_at.elapsed() >= STREAM_STALE_AFTER {
+                        debug!("SERVO_OUTPUT_RAW stale; re-requesting message interval");
+                        // Best-effort; next tick retries if the autopilot is quiet.
+                        let _ = tokio::time::timeout(
+                            SERVO_REQUEST_TIMEOUT,
+                            request_servo_stream(SERVO_STREAM_INTERVAL_US),
+                        )
+                        .await;
+                    }
+                }
+                _ = INTEREST_CHANGED.notified() => {
+                    if INTEREST.load(Ordering::SeqCst) > 0 {
+                        // Best-effort; refresh tick retries if the autopilot is quiet.
+                        let _ = tokio::time::timeout(
+                            SERVO_REQUEST_TIMEOUT,
+                            request_servo_stream(SERVO_STREAM_INTERVAL_US),
+                        )
+                        .await;
+                        last_servo_at = Instant::now();
+                    } else {
+                        // Best-effort disable; shutdown() also times this out.
+                        let _ = tokio::time::timeout(
+                            SERVO_REQUEST_TIMEOUT,
+                            request_servo_stream(STREAM_DISABLED_INTERVAL_US),
+                        )
+                        .await;
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[instrument(level = "debug", skip_all)]
+async fn open_receiver() -> Option<(broadcast::Receiver<Message>, u8)> {
+    let manager = MANAGER.get()?.read().await;
+    let receiver = manager.mavlink.get_receiver().await;
+    let target_system = manager.mavlink.inner.system_id;
+    Some((receiver, target_system))
+}
+
+#[instrument(level = "debug")]
+async fn request_servo_stream(interval_us: f32) {
+    let Some(manager) = MANAGER.get() else {
+        return;
+    };
+    let manager = manager.read().await;
+    if let Err(error) = manager
+        .mavlink
+        .set_message_interval(SERVO_OUTPUT_RAW_DATA::ID, interval_us)
+        .await
+    {
+        debug!("Failed setting SERVO_OUTPUT_RAW stream interval: {error:?}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn emit_gate_dedups_identical_state() {
+        let (sender, mut receiver) = broadcast::channel(8);
+        let mut gate = EmitGate {
+            last_emitted: HashMap::new(),
+            last_emit_at: HashMap::new(),
+            pending: HashMap::new(),
+        };
+        let camera_uuid = Uuid::nil();
+        let state = api::ActuatorsState {
+            focus: Some(10.0),
+            zoom: Some(20.0),
+            tilt: Some(30.0),
+        };
+
+        gate.try_emit(camera_uuid, state, &sender);
+        gate.try_emit(camera_uuid, state, &sender);
+
+        assert!(receiver.try_recv().is_ok());
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn interest_refcount_saturates_at_zero() {
+        add_interest();
+        add_interest();
+        assert_eq!(INTEREST.load(Ordering::SeqCst), 2);
+
+        remove_interest();
+        remove_interest();
+        remove_interest();
+        assert_eq!(INTEREST.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn emit_gate_queues_when_throttled() {
+        let (sender, mut receiver) = broadcast::channel(8);
+        let mut gate = EmitGate {
+            last_emitted: HashMap::new(),
+            last_emit_at: HashMap::new(),
+            pending: HashMap::new(),
+        };
+        let camera_uuid = Uuid::nil();
+        let first = api::ActuatorsState {
+            focus: Some(1.0),
+            zoom: None,
+            tilt: None,
+        };
+        let second = api::ActuatorsState {
+            focus: Some(2.0),
+            zoom: None,
+            tilt: None,
+        };
+
+        gate.try_emit(camera_uuid, first, &sender);
+        gate.try_emit(camera_uuid, second, &sender);
+        assert!(receiver.try_recv().is_ok());
+        assert!(receiver.try_recv().is_err());
+        assert!(gate.pending.contains_key(&camera_uuid));
+
+        // Pretend enough time passed.
+        gate.last_emit_at
+            .insert(camera_uuid, Instant::now() - MIN_EMIT_INTERVAL);
+        gate.flush_pending(&sender);
+        let update = receiver.try_recv().expect("pending flush");
+        assert_eq!(update.state.focus, Some(2.0));
+    }
+}

--- a/backend/libs/autopilot/src/manager/mod.rs
+++ b/backend/libs/autopilot/src/manager/mod.rs
@@ -85,7 +85,7 @@ impl Manager {
             .settings
             .actuators
             .get_mut(camera_uuid)
-            .context("Camera's actuators not configured")?;
+            .context(crate::ACTUATORS_NOT_CONFIGURED)?;
 
         let servo_output_raw = self
             .mavlink
@@ -93,44 +93,8 @@ impl Manager {
             .await
             .context("Failed waiting for SERVO_OUTPUT_RAW_DATA message")?;
 
-        let focus = {
-            let (channel, min, max) = if actuators.parameters.enable_focus_and_zoom_correlation {
-                (
-                    actuators.parameters.script_channel,
-                    actuators.parameters.script_channel_min,
-                    actuators.parameters.script_channel_max,
-                )
-            } else {
-                (
-                    actuators.parameters.focus_channel,
-                    actuators.parameters.focus_channel_min,
-                    actuators.parameters.focus_channel_max,
-                )
-            };
-
-            get_output_raw_from_channel(&servo_output_raw, channel)
-                .map(|value| percentage_within_range(value, min, max))
-        };
-
-        let zoom = {
-            let channel = actuators.parameters.zoom_channel;
-            let min = actuators.parameters.zoom_channel_min;
-            let max = actuators.parameters.zoom_channel_max;
-
-            get_output_raw_from_channel(&servo_output_raw, channel)
-                .map(|value| percentage_within_range(value, min, max))
-        };
-
-        let tilt = {
-            let channel = actuators.parameters.tilt_channel;
-            let min = actuators.parameters.tilt_channel_min;
-            let max = actuators.parameters.tilt_channel_max;
-
-            get_output_raw_from_channel(&servo_output_raw, channel)
-                .map(|value| percentage_within_range(value, min, max))
-        };
-
-        actuators.state = api::ActuatorsState { focus, zoom, tilt };
+        let state = actuators_state_from_servo(actuators, &servo_output_raw);
+        actuators.state = state;
 
         Ok(actuators.state)
     }
@@ -177,13 +141,24 @@ impl Manager {
                 .context("Failed sending MAV_CMD_SET_CAMERA_ZOOM command")?;
         }
 
-        let _ = self.get_state(camera_uuid).await;
-
-        if focus_was_set {
-            self.check_focus_script_health(camera_uuid).await;
+        // Prefer measured SERVO positions so the WS stream does not treat the
+        // requested setpoint as authoritative when the autopilot never moved.
+        match self.get_state(camera_uuid).await {
+            Ok(measured) => {
+                if focus_was_set {
+                    self.check_focus_script_health(camera_uuid).await;
+                }
+                Ok(measured)
+            }
+            Err(error) => {
+                debug!("Failed reading actuators after set: {error:?}");
+                if focus_was_set {
+                    self.check_focus_script_health(camera_uuid).await;
+                }
+                // Fall back so the UI stays responsive when the SERVO stream is quiet.
+                Ok(*new_state)
+            }
         }
-
-        Ok(*new_state)
     }
 
     #[instrument(level = "debug", skip(self))]
@@ -299,6 +274,8 @@ pub async fn init(
         })
     });
 
+    crate::actuators_watch::start();
+
     Ok(())
 }
 
@@ -346,4 +323,53 @@ fn percentage_within_range(value: u16, min: u16, max: u16) -> f32 {
     }
     let clamped = value.clamp(min, max);
     (100.0 * ((clamped - min) as f32 / (max - min) as f32)).round()
+}
+
+/// Builds an [`api::ActuatorsState`] from a raw `SERVO_OUTPUT_RAW` sample.
+///
+/// When `enable_focus_and_zoom_correlation` is set, focus is read from the script
+/// channel instead of the dedicated focus channel. Each axis is `None` when its
+/// channel is unmapped.
+pub(crate) fn actuators_state_from_servo(
+    actuators: &CameraActuators,
+    servo_output_raw: &SERVO_OUTPUT_RAW_DATA,
+) -> api::ActuatorsState {
+    let focus = {
+        let (channel, min, max) = if actuators.parameters.enable_focus_and_zoom_correlation {
+            (
+                actuators.parameters.script_channel,
+                actuators.parameters.script_channel_min,
+                actuators.parameters.script_channel_max,
+            )
+        } else {
+            (
+                actuators.parameters.focus_channel,
+                actuators.parameters.focus_channel_min,
+                actuators.parameters.focus_channel_max,
+            )
+        };
+
+        get_output_raw_from_channel(servo_output_raw, channel)
+            .map(|value| percentage_within_range(value, min, max))
+    };
+
+    let zoom = {
+        let channel = actuators.parameters.zoom_channel;
+        let min = actuators.parameters.zoom_channel_min;
+        let max = actuators.parameters.zoom_channel_max;
+
+        get_output_raw_from_channel(servo_output_raw, channel)
+            .map(|value| percentage_within_range(value, min, max))
+    };
+
+    let tilt = {
+        let channel = actuators.parameters.tilt_channel;
+        let min = actuators.parameters.tilt_channel_min;
+        let max = actuators.parameters.tilt_channel_max;
+
+        get_output_raw_from_channel(servo_output_raw, channel)
+            .map(|value| percentage_within_range(value, min, max))
+    };
+
+    api::ActuatorsState { focus, zoom, tilt }
 }

--- a/backend/libs/autopilot/src/manager/script.rs
+++ b/backend/libs/autopilot/src/manager/script.rs
@@ -22,7 +22,7 @@ impl Manager {
             .settings
             .actuators
             .get(camera_uuid)
-            .context("Camera's actuators not configured")?;
+            .context(crate::ACTUATORS_NOT_CONFIGURED)?;
         let path = &self.autopilot_scripts_file;
 
         let contents = generate_lua_script(camera_actuators)?;

--- a/backend/libs/autopilot/src/mavlink/mod.rs
+++ b/backend/libs/autopilot/src/mavlink/mod.rs
@@ -1,6 +1,8 @@
 mod connection;
 pub mod parameters;
 
+pub use connection::Message;
+
 use std::sync::Arc;
 
 use anyhow::{Context, Result, anyhow};
@@ -13,10 +15,7 @@ use tokio::sync::{RwLock, broadcast};
 use tracing::*;
 
 use crate::{
-    mavlink::{
-        connection::{Connection, Message},
-        parameters::ParamEncodingType,
-    },
+    mavlink::{connection::Connection, parameters::ParamEncodingType},
     parameters::{ParamType, Parameter},
 };
 
@@ -349,6 +348,30 @@ impl MavlinkComponent {
             "Command {:?} timed out after {max_retries} retries",
             command.command
         ))
+    }
+
+    /// Subscribe to the shared MAVLink message broadcast for this component.
+    #[instrument(level = "debug", skip(self))]
+    pub async fn get_receiver(&self) -> broadcast::Receiver<Message> {
+        self.inner.get_receiver().await
+    }
+
+    /// Request the autopilot to stream `message_id` at `interval_us` microseconds.
+    #[instrument(level = "debug", skip(self))]
+    pub async fn set_message_interval(&self, message_id: u32, interval_us: f32) -> Result<()> {
+        let target_system = self.inner.system_id;
+        let target_component = mavlink::ardupilotmega::MavComponent::MAV_COMP_ID_AUTOPILOT1 as u8;
+
+        self.send_command(COMMAND_LONG_DATA {
+            command: MavCmd::MAV_CMD_SET_MESSAGE_INTERVAL,
+            target_system,
+            target_component,
+            confirmation: 0,
+            param1: message_id as f32,
+            param2: interval_us,
+            ..Default::default()
+        })
+        .await
     }
 
     pub async fn request_servo_output_raw(&self) -> Result<SERVO_OUTPUT_RAW_DATA> {

--- a/backend/libs/autopilot/src/mod.rs
+++ b/backend/libs/autopilot/src/mod.rs
@@ -1,8 +1,9 @@
+mod actuators_watch;
 pub mod api;
 mod manager;
 mod mavlink;
 pub mod parameters;
-pub mod routes;
+mod routes;
 mod settings_translations;
 
 use anyhow::{Context, Result};
@@ -10,14 +11,21 @@ use axum::Json;
 use serde::{Deserialize, Serialize};
 use tracing::*;
 
+pub use actuators_watch::{
+    add_interest as add_actuators_state_interest,
+    remove_interest as remove_actuators_state_interest, shutdown as shutdown_actuators_stream,
+    subscribe as subscribe_actuators_state,
+};
 pub use manager::{clear_saved_settings, init};
+pub use routes::router;
 
 use crate::{
     manager::MANAGER,
     parameters::{ActuatorsParameters, CLOSEST_POINTS, FURTHEST_POINTS},
 };
 
-pub use routes::router;
+/// Context message when a camera has no actuators entry yet.
+pub const ACTUATORS_NOT_CONFIGURED: &str = "Camera's actuators not configured";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 struct CameraActuators {
@@ -36,6 +44,17 @@ impl Default for CameraActuators {
             state: api::ActuatorsState::default(),
         }
     }
+}
+
+/// True when `message` (e.g. `format!("{error:?}")`) carries [`ACTUATORS_NOT_CONFIGURED`].
+pub fn error_indicates_actuators_not_configured(message: &str) -> bool {
+    message.contains(ACTUATORS_NOT_CONFIGURED)
+}
+
+/// Shared entry point for REST and WebSocket autopilot control requests.
+#[instrument(level = "debug")]
+pub async fn handle_control(actuators_control: api::ActuatorsControl) -> Result<serde_json::Value> {
+    control_inner(Json(actuators_control)).await
 }
 
 #[instrument(level = "debug")]
@@ -88,7 +107,7 @@ pub(crate) async fn control_inner(
                 .settings
                 .actuators
                 .get(&actuators_control.camera_uuid)
-                .context("Camera's actuators not configured")?
+                .context(crate::ACTUATORS_NOT_CONFIGURED)?
                 .into();
 
             serde_json::to_value(config)?
@@ -120,7 +139,7 @@ pub(crate) async fn control_inner(
                 .settings
                 .actuators
                 .get(&actuators_control.camera_uuid)
-                .context("Camera's actuators not configured")?
+                .context(crate::ACTUATORS_NOT_CONFIGURED)?
                 .into();
 
             serde_json::to_value(config)?
@@ -134,7 +153,7 @@ pub(crate) async fn control_inner(
                 .settings
                 .actuators
                 .get(&actuators_control.camera_uuid)
-                .context("Camera's actuators not configured")?
+                .context(crate::ACTUATORS_NOT_CONFIGURED)?
                 .into();
 
             serde_json::to_value(config)?
@@ -142,4 +161,22 @@ pub(crate) async fn control_inner(
     };
 
     Ok(res)
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::anyhow;
+
+    use super::{ACTUATORS_NOT_CONFIGURED, error_indicates_actuators_not_configured};
+
+    #[test]
+    fn actuators_not_configured_message_is_stable() {
+        let error = anyhow!("missing entry").context(ACTUATORS_NOT_CONFIGURED);
+        assert!(error_indicates_actuators_not_configured(&format!(
+            "{error:?}"
+        )));
+        assert!(!error_indicates_actuators_not_configured(
+            "Camera actuators unavailable"
+        ));
+    }
 }


### PR DESCRIPTION
## Summary
Split from the websockets work: **Demand-gated SERVO watch and autopilot handle_control**.

Commits in this slice:
- `backend: libs: autopilot: Add demand-gated SERVO watch and shared handle_control`

## Stack
- Part **2/24** of the websockets split (all PRs target `master`)
- Depends on https://github.com/bluerobotics/radcam-manager/pull/202 merging first.
- After the previous stack PR merges: rebase this branch onto `master` and `git push --force-with-lease`
- Intermediate slices may show **red CI** (incomplete stack / missing later fixes). That is expected.
- The batch is only done when tip **[#225](https://github.com/bluerobotics/radcam-manager/pull/225)** (`24/24`) is green after the full merge-rebase dance.

## Test plan
- [ ] SERVO stream is requested only while something holds actuators interest
- [ ] Dropping interest stops refreshing SERVO / does not leave a stuck watcher
- [ ] Autopilot `handle_control` still applies focus/zoom/tilt setpoints
