### PR TITLE
websockets 08/24: Generate TypeScript bindings from radcam_api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,7 @@ dependencies = [
  "anyhow",
  "autopilot",
  "mcm_client",
+ "radcam_api",
  "radcam_commands",
  "regex",
  "ts-rs",

--- a/backend/bindings_generator/Cargo.toml
+++ b/backend/bindings_generator/Cargo.toml
@@ -15,6 +15,7 @@ bench = false
 autopilot = { path="../libs/autopilot" }
 radcam_commands = { path="../libs/radcam_commands" }
 mcm_client = { path = "../libs/mcm_client" }
+radcam_api = { path = "../libs/radcam_api" }
 
 anyhow = { workspace = true }
 ts-rs = { workspace = true }

--- a/backend/bindings_generator/src/main.rs
+++ b/backend/bindings_generator/src/main.rs
@@ -1,11 +1,14 @@
-use std::{fs, path::PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use autopilot::api;
 use regex::Regex;
 use ts_rs::TS;
 
-use mcm_client::{Camera, Credentials, Stream, mcm_types};
+use mcm_client::{Camera, Stream, mcm_types};
 use radcam_commands::{
     Action, CameraControl,
     protocol::display::{
@@ -29,6 +32,11 @@ fn main() -> Result<()> {
         return Err(error);
     }
 
+    if let Err(error) = generate_typescript_bindings_for_radcam_api() {
+        println!("Failed generating typescript bindings for RadCam API: {error:?}");
+        return Err(error);
+    }
+
     println!("Typescript bindings successifully generated!");
 
     Ok(())
@@ -40,10 +48,7 @@ fn generate_typescript_bindings_for_mcm_client() -> Result<()> {
     let inputs = vec![root_dir.join("backend/libs/mcm_client")];
     let output = root_dir.join("frontend/src/bindings/mcm_client.d.ts");
 
-    if fs::remove_file(output.clone()).is_err() {
-        let output_dir = output.parent().unwrap();
-        fs::create_dir_all(output_dir).unwrap();
-    }
+    prepare_output(&output)?;
 
     let tsync_bindings = {
         tsync::generate_typescript_defs(inputs, output.clone(), false, false);
@@ -54,60 +59,39 @@ fn generate_typescript_bindings_for_mcm_client() -> Result<()> {
             .replace("interface ", "export interface ")
     };
 
-    let ts_rs_bindings = {
-        // Generate all typescript bindings and join them into a single String
-        let bindings = [
-            Camera::export_to_string()?,
-            Credentials::export_to_string()?,
-            Stream::export_to_string()?,
-            mcm_types::VideoEncodeType::export_to_string()?,
-            mcm_types::CaptureConfiguration::export_to_string()?,
-            mcm_types::VideoSourceType::export_to_string()?,
-            mcm_types::VideoSourceOnvifType::export_to_string()?,
-            mcm_types::Info::export_to_string()?,
-            mcm_types::ApiVideoSource::export_to_string()?,
-            mcm_types::Format::export_to_string()?,
-            mcm_types::Size::export_to_string()?,
-            mcm_types::FrameInterval::export_to_string()?,
-            mcm_types::StreamInformation::export_to_string()?,
-            mcm_types::ExtendedConfiguration::export_to_string()?,
-            mcm_types::VideoCaptureConfiguration::export_to_string()?,
-            mcm_types::RedirectCaptureConfiguration::export_to_string()?,
-            mcm_types::StreamStatus::export_to_string()?,
-            mcm_types::VideoAndStreamInformation::export_to_string()?,
-            mcm_types::VideoSourceOnvif::export_to_string()?,
-            mcm_types::VideoSourceLocal::export_to_string()?,
-            mcm_types::VideoSourceGst::export_to_string()?,
-            mcm_types::VideoSourceRedirect::export_to_string()?,
-            mcm_types::OnvifDeviceInformation::export_to_string()?,
-            mcm_types::PostStream::export_to_string()?,
-            mcm_types::RemoveStream::export_to_string()?,
-            mcm_types::OnvifDevice::export_to_string()?,
-            mcm_types::AuthenticateOnvifDeviceRequest::export_to_string()?,
-            mcm_types::UnauthenticateOnvifDeviceRequest::export_to_string()?,
-        ]
-        .join("\n\n");
+    // Generate all typescript bindings and join them into a single String
+    let ts_rs_bindings = [
+        Camera::export_to_string()?,
+        Stream::export_to_string()?,
+        mcm_types::VideoEncodeType::export_to_string()?,
+        mcm_types::CaptureConfiguration::export_to_string()?,
+        mcm_types::VideoSourceType::export_to_string()?,
+        mcm_types::VideoSourceOnvifType::export_to_string()?,
+        mcm_types::Info::export_to_string()?,
+        mcm_types::ApiVideoSource::export_to_string()?,
+        mcm_types::Format::export_to_string()?,
+        mcm_types::Size::export_to_string()?,
+        mcm_types::FrameInterval::export_to_string()?,
+        mcm_types::StreamInformation::export_to_string()?,
+        mcm_types::ExtendedConfiguration::export_to_string()?,
+        mcm_types::VideoCaptureConfiguration::export_to_string()?,
+        mcm_types::RedirectCaptureConfiguration::export_to_string()?,
+        mcm_types::StreamStatus::export_to_string()?,
+        mcm_types::VideoAndStreamInformation::export_to_string()?,
+        mcm_types::VideoSourceOnvif::export_to_string()?,
+        mcm_types::VideoSourceLocal::export_to_string()?,
+        mcm_types::VideoSourceGst::export_to_string()?,
+        mcm_types::VideoSourceRedirect::export_to_string()?,
+        mcm_types::OnvifDeviceInformation::export_to_string()?,
+        mcm_types::PostStream::export_to_string()?,
+        mcm_types::RemoveStream::export_to_string()?,
+        mcm_types::OnvifDevice::export_to_string()?,
+        mcm_types::AuthenticateOnvifDeviceRequest::export_to_string()?,
+        mcm_types::UnauthenticateOnvifDeviceRequest::export_to_string()?,
+    ]
+    .join("\n\n");
 
-        // // Remove all typescript "import type" because all types are going to live in the same typescritp file
-        let re = Regex::new(r"(?m)^import type .*\n")?;
-        re.replace_all(bindings.as_str(), "").to_string()
-    };
-
-    let bindings = ts_rs_bindings + &tsync_bindings;
-
-    // Replace all notices by a custom one
-    let bindings = {
-        let re = Regex::new(r".*This file.*")?;
-        let mut bindings = re.replace_all(bindings.as_str(), "\n").to_string();
-
-        let custom_notice_str = "/* This file was generated using `cargo run --bin=bindings`. Do not edit this file manually. */\n";
-        bindings.insert_str(0, custom_notice_str);
-        bindings.as_str().replace("\n\n\n", "\n")
-    };
-
-    fs::write(output, bindings)?;
-
-    Ok(())
+    write_bindings(&output, ts_rs_bindings + &tsync_bindings)
 }
 
 fn generate_typescript_bindings_for_autopilot() -> Result<()> {
@@ -116,10 +100,7 @@ fn generate_typescript_bindings_for_autopilot() -> Result<()> {
     let inputs = vec![root_dir.join("backend/libs/autopilot")];
     let output = root_dir.join("frontend/src/bindings/autopilot.d.ts");
 
-    if fs::remove_file(output.clone()).is_err() {
-        let output_dir = output.parent().unwrap();
-        fs::create_dir_all(output_dir).unwrap();
-    }
+    prepare_output(&output)?;
 
     let tsync_bindings = {
         tsync::generate_typescript_defs(inputs, output.clone(), false, false);
@@ -130,43 +111,23 @@ fn generate_typescript_bindings_for_autopilot() -> Result<()> {
             .replace("interface ", "export interface ")
     };
 
-    let ts_rs_bindings = {
-        // Generate all typescript bindings and join them into a single String
-        let bindings = [
-            api::ActuatorsControl::export_to_string()?,
-            api::Action::export_to_string()?,
-            api::ActuatorsState::export_to_string()?,
-            api::ActuatorsConfig::export_to_string()?,
-            api::ActuatorsParametersConfig::export_to_string()?,
-            api::ServoChannel::export_to_string()?,
-            api::MountType::export_to_string()?,
-            api::CameraID::export_to_string()?,
-            api::ScriptFunction::export_to_string()?,
-            api::FocusZoomPoints::export_to_string()?,
-            api::FocusZoomPoint::export_to_string()?,
-        ]
-        .join("\n\n");
+    // Generate all typescript bindings and join them into a single String
+    let ts_rs_bindings = [
+        api::ActuatorsControl::export_to_string()?,
+        api::Action::export_to_string()?,
+        api::ActuatorsState::export_to_string()?,
+        api::ActuatorsConfig::export_to_string()?,
+        api::ActuatorsParametersConfig::export_to_string()?,
+        api::ServoChannel::export_to_string()?,
+        api::MountType::export_to_string()?,
+        api::CameraID::export_to_string()?,
+        api::ScriptFunction::export_to_string()?,
+        api::FocusZoomPoints::export_to_string()?,
+        api::FocusZoomPoint::export_to_string()?,
+    ]
+    .join("\n\n");
 
-        // // Remove all typescript "import type" because all types are going to live in the same typescritp file
-        let re = Regex::new(r"(?m)^import type .*\n")?;
-        re.replace_all(bindings.as_str(), "").to_string()
-    };
-
-    let bindings = ts_rs_bindings + &tsync_bindings;
-
-    // Replace all notices by a custom one
-    let bindings = {
-        let re = Regex::new(r".*This file.*")?;
-        let mut bindings = re.replace_all(bindings.as_str(), "\n").to_string();
-
-        let custom_notice_str = "/* This file was generated using `cargo run --bin=bindings`. Do not edit this file manually. */\n";
-        bindings.insert_str(0, custom_notice_str);
-        bindings.as_str().replace("\n\n\n", "\n")
-    };
-
-    fs::write(output, bindings)?;
-
-    Ok(())
+    write_bindings(&output, ts_rs_bindings + &tsync_bindings)
 }
 
 fn generate_typescript_bindings_for_radcam() -> Result<()> {
@@ -175,7 +136,7 @@ fn generate_typescript_bindings_for_radcam() -> Result<()> {
     let inputs = vec![root_dir.join("backend/libs/radcam_commands")];
     let output = root_dir.join("frontend/src/bindings/radcam.ts");
 
-    let _ = fs::remove_file(output.clone());
+    prepare_output(&output)?;
 
     let tsync_bindings = {
         tsync::generate_typescript_defs(inputs, output.clone(), false, false);
@@ -185,34 +146,78 @@ fn generate_typescript_bindings_for_radcam() -> Result<()> {
             .replace("type ", "export type ")
     };
 
-    let ts_rs_bindings = {
-        // Generate all typescript bindings and join them into a single String
-        let bindings = [
-            CameraControl::export_to_string()?,
-            Action::export_to_string()?,
-            BaseParameterSetting::export_to_string()?,
-            AdvancedParameterSetting::export_to_string()?,
-        ]
-        .join("\n\n");
+    // Generate all typescript bindings and join them into a single String
+    let ts_rs_bindings = [
+        CameraControl::export_to_string()?,
+        Action::export_to_string()?,
+        BaseParameterSetting::export_to_string()?,
+        AdvancedParameterSetting::export_to_string()?,
+    ]
+    .join("\n\n");
 
-        // Remove all typescript "import type" because all types are going to live in the same typescritp file
-        let re = Regex::new(r"(?m)^import type .*\n")?;
-        re.replace_all(bindings.as_str(), "").to_string()
-    };
+    write_bindings(&output, ts_rs_bindings + &tsync_bindings)
+}
 
-    let bindings = ts_rs_bindings + &tsync_bindings;
+fn generate_typescript_bindings_for_radcam_api() -> Result<()> {
+    let root_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../");
+    let output = root_dir.join("frontend/src/bindings/radcam_api.d.ts");
 
-    // Replace all notices by a custom one
-    let bindings = {
-        let re = Regex::new(r".*This file.*")?;
-        let mut bindings = re.replace_all(bindings.as_str(), "\n").to_string();
+    prepare_output(&output)?;
 
-        let custom_notice_str = "/* This file was generated using `cargo run --bin=bindings`. Do not edit this file manually. */\n";
-        bindings.insert_str(0, custom_notice_str);
-        bindings.as_str().replace("\n\n\n", "\n")
-    };
+    let ts_rs_bindings = [
+        radcam_api::CameraStateEvent::export_to_string()?,
+        radcam_api::CameraUiState::export_to_string()?,
+        radcam_api::ConnectionStats::export_to_string()?,
+        radcam_api::WsRequest::export_to_string()?,
+        radcam_api::WsClientMessage::export_to_string()?,
+        radcam_api::UiDismissField::export_to_string()?,
+        radcam_api::WsResponse::export_to_string()?,
+        radcam_api::WsEvent::export_to_string()?,
+    ]
+    .join("\n\n");
 
-    fs::write(output, bindings)?;
+    write_bindings(&output, ts_rs_bindings)
+}
+
+/// Removes a stale bindings file, creating its parent directory when missing.
+fn prepare_output(output: &Path) -> Result<()> {
+    match fs::remove_file(output) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("Failed removing stale bindings at {output:?}"));
+        }
+    }
+
+    if let Some(output_dir) = output.parent() {
+        fs::create_dir_all(output_dir)
+            .with_context(|| format!("Failed creating bindings directory {output_dir:?}"))?;
+    }
+
+    Ok(())
+}
+
+/// Strips per-type imports, replaces the generator notices by a custom one, and writes the file.
+fn write_bindings(output: &Path, bindings: String) -> Result<()> {
+    // Remove all typescript "import type" because all types are going to live in the same typescript file
+    let re = Regex::new(r"(?m)^import type .*\n")?;
+    let bindings = re.replace_all(bindings.as_str(), "").to_string();
+
+    let re = Regex::new(r".*This file.*")?;
+    let mut bindings = re.replace_all(bindings.as_str(), "\n").to_string();
+
+    let custom_notice_str = "/* This file was generated using `cargo run --bin=bindings`. Do not edit this file manually. */\n";
+    bindings.insert_str(0, custom_notice_str);
+
+    fs::write(output, bindings.as_str().replace("\n\n\n", "\n"))?;
+
+    println!(
+        "Successfully wrote {:?}",
+        output
+            .canonicalize()
+            .unwrap_or_else(|_| output.to_path_buf())
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
Split from the websockets work: **Generate TypeScript bindings from radcam_api**.

Commits in this slice:
- `backend: bindings_generator: Generate TypeScript bindings from radcam_api`

## Stack
- Part **8/24** of the websockets split (all PRs target `master`)
- Depends on https://github.com/bluerobotics/radcam-manager/pull/208 merging first.
- After the previous stack PR merges: rebase this branch onto `master` and `git push --force-with-lease`
- Intermediate slices may show **red CI** (incomplete stack / missing later fixes). That is expected.
- The batch is only done when tip **[#225](https://github.com/bluerobotics/radcam-manager/pull/225)** (`24/24`) is green after the full merge-rebase dance.

## Test plan
- [ ] Regenerated `frontend/src/bindings/radcam_api.d.ts` matches `radcam_api` exports
- [ ] Frontend typecheck accepts the new envelopes (`WsRequest`, `CameraStateEvent`, …)
- [ ] Bindings generator still runs in CI/build
