### PR TITLE
websockets 10/24: Switch HomeView to WebSocket client and shared UI overlays

### DIFF
--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -29,18 +29,24 @@
               </v-icon>
             </template>
             <v-list class="pa-0 border-[1px] border-[#ffffff22] rounded-[4px]">
-              <v-list-item @click="updateLuaScript">
+              <v-list-item
+                :disabled="!backendConnected"
+                @click="updateLuaScript"
+              >
                 <v-list-item-title class="flex">
                   Update Lua script
                 </v-list-item-title>
               </v-list-item>
-              <v-list-item @click="applyRecommendedCameraSettings">
+              <v-list-item
+                :disabled="!backendConnected || selectedCameraUUID == null"
+                @click="applyRecommendedCameraSettings"
+              >
                 <v-list-item-title class="flex">
                   Apply Recommended Camera Settings
                 </v-list-item-title>
               </v-list-item>
               <v-list-item
-                :disabled="selectedCameraUUID == null"
+                :disabled="!backendConnected || selectedCameraUUID == null"
                 @click="rebootCamera"
               >
                 <v-list-item-title class="flex">
@@ -69,22 +75,79 @@
             </template>
           </v-select>
         </div>
-        <BlueButtonGroup
-          :button-items="configButtons"
-          :theme="theme"
-          class="mr-4"
-          type="switch"
-        />
+        <div class="flex items-center mr-4">
+          <v-tooltip
+            location="bottom"
+            open-delay="200"
+          >
+            <template #activator="{ props: tooltipProps }">
+              <span
+                v-bind="tooltipProps"
+                class="connection-status-wrap"
+              >
+                <v-icon
+                  :icon="connectionIcon"
+                  :color="connectionColor"
+                  size="14"
+                  class="connection-status-icon"
+                  :class="{ 'connection-status-icon--spinning': connectionState === 'connecting' }"
+                />
+              </span>
+            </template>
+            <div class="connection-stats-tooltip text-sm leading-snug">
+              <div>{{ connectionStatusLine }}</div>
+              <template v-if="connectionState === 'connected' && connectionStats">
+                <div>{{ connectionStats.clients_connected }} {{ connectionStats.clients_connected === 1 ? 'client' : 'clients' }} connected</div>
+                <div class="connection-stats-bandwidth">
+                  <span class="connection-stats-label">This</span>
+                  <v-icon
+                    icon="mdi-arrow-up"
+                    size="12"
+                    class="mr-1"
+                  />
+                  {{ formatKbps(connectionStats.this_upload_kbps) }}
+                  <v-icon
+                    icon="mdi-arrow-down"
+                    size="12"
+                    class="mx-1"
+                  />
+                  {{ formatKbps(connectionStats.this_download_kbps) }} kbps
+                </div>
+                <div class="connection-stats-bandwidth">
+                  <span class="connection-stats-label">All</span>
+                  <v-icon
+                    icon="mdi-arrow-up"
+                    size="12"
+                    class="mr-1"
+                  />
+                  {{ formatKbps(connectionStats.total_upload_kbps) }}
+                  <v-icon
+                    icon="mdi-arrow-down"
+                    size="12"
+                    class="mx-1"
+                  />
+                  {{ formatKbps(connectionStats.total_download_kbps) }} kbps
+                </div>
+              </template>
+            </div>
+          </v-tooltip>
+          <BlueButtonGroup
+            :button-items="configButtons"
+            :theme="theme"
+            type="switch"
+          />
+        </div>
       </div>
       <div
         class="min-w-[650px] transition-all duration-300 ease-in-out"
       >
         <div v-if="configMode === 'basic'">
           <BasicSettings
+            :backend-api="backendAPI"
             ref="cameraControls"
             :selected-camera-uuid="selectedCameraUUID"
-            :backend-api="backendAPI"
-            :disabled="selectedCameraUUID == null"
+            :disabled="!backendConnected || selectedCameraUUID == null || uiLoading || uiRebooting"
+            :loading="uiLoading"
             :cockpit-mode="isCockpitMode"
           />
         </div>
@@ -113,14 +176,14 @@
               <ImageTab
                 :backend-api="backendAPI"
                 :selected-camera-uuid="selectedCameraUUID"
-                :disabled="selectedCameraUUID == null"
+                :disabled="!backendConnected || selectedCameraUUID == null || uiLoading || uiRebooting"
               />
             </v-tabs-window-item>
             <v-tabs-window-item value="streams">
               <StreamsTab
                 :backend-api="backendAPI"
                 :selected-camera-uuid="selectedCameraUUID"
-                :disabled="selectedCameraUUID == null"
+                :disabled="!backendConnected || selectedCameraUUID == null || uiLoading || uiRebooting"
               />
             </v-tabs-window-item>
           </v-tabs-window>
@@ -128,42 +191,104 @@
       </div>
     </v-container>
   <Loading
-    :is-loading="menuActionLoading"
-    :message="menuActionMessage"
+    :is-loading="uiLoading"
+    :message="uiLoadingMessage"
   />
   <ErrorDialog
     :message="errorDialogMessage"
-    @close="errorDialogMessage = null"
+    @close="dismissErrorDialog"
   />
+  <WarningToast :message="warningToastMessage" />
 </template>
 
 <script setup lang="ts">
-import axios from 'axios'
-import { onMounted, onUnmounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRouteQuery } from '@vueuse/router'
 
 import type { Camera } from '@/bindings/mcm_client'
+import type { CameraStateEvent, CameraUiState } from '@/bindings/radcam_api'
 import BasicSettings from '@/components/BasicSettings.vue'
 import BlueButtonGroup from '@/components/BlueButtonGroup.vue'
 import ImageTab from '@/components/ImageTab.vue'
 import StreamsTab from '@/components/StreamsTab.vue'
+import WarningToast from '@/components/WarningToast.vue'
+import { backendClient, type ConnectionState, type ConnectionStats } from '@/utils/backendClient'
 import { formatRequestError } from '@/utils/formatRequestError'
-import { endMinLoading, startMinLoading } from '@/utils/minLoadingDuration'
 
 const tab = ref(null)
-// const backendAPI = ref(`http://192.168.2.2:<radcam-extension-port>/v1`) // For local frontend development:
-const backendAPI = ref('v1')
 const cameras = ref<Camera[]>([])
 const selectedCameraUUID = ref<string | null>(null)
+const backendAPI = ref('v1')
+const connectionState = ref<ConnectionState>('disconnected')
+const connectionStats = ref<ConnectionStats | null>(null)
+const disconnectedSince = ref<Date | null>(null)
+
+const sinceFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+})
+
+const formatSince = (value: string | Date): string => {
+  const date = value instanceof Date ? value : new Date(value)
+  return sinceFormatter.format(date)
+}
+
+const formatKbps = (kbps: number): string => {
+  if (kbps < 10) {
+    return kbps.toFixed(1)
+  }
+  return Math.round(kbps).toString()
+}
+
+const connectionStatusLine = computed(() => {
+  if (connectionState.value === 'connecting') {
+    return 'Connecting…'
+  }
+  if (connectionState.value === 'connected' && connectionStats.value) {
+    return `Connected since ${formatSince(connectionStats.value.since)}`
+  }
+  if (connectionState.value === 'disconnected' && disconnectedSince.value) {
+    return `Disconnected since ${formatSince(disconnectedSince.value)}`
+  }
+  return 'Disconnected'
+})
+
+const connectionIcon = computed(() => {
+  switch (connectionState.value) {
+    case 'connected':
+      return 'mdi-lan-connect'
+    case 'connecting':
+      return 'mdi-sync'
+    case 'disconnected':
+    default:
+      return 'mdi-lan-disconnect'
+  }
+})
+
+const connectionColor = computed(() => {
+  switch (connectionState.value) {
+    case 'connected':
+      return '#66bb6a'
+    case 'connecting':
+      return '#ffb74d'
+    case 'disconnected':
+    default:
+      return '#ef5350'
+  }
+})
+
+const backendConnected = computed(() => connectionState.value === 'connected')
 
 const desiredCameraUuid = useRouteQuery<string | null>('uuid', null)
 
 const theme = ref<'light' | 'dark'>('dark')
 const configMode = ref<'basic' | 'advanced'>('basic')
 const cameraControls = ref<InstanceType<typeof BasicSettings> | null>(null)
-const menuActionLoading = ref(false)
-const menuActionMessage = ref('Applying settings…')
+const uiLoading = ref(false)
+const uiLoadingMessage = ref('Applying settings…')
+const uiRebooting = ref(false)
 const errorDialogMessage = ref<string | null>(null)
+const warningToastMessage = ref<string | null>(null)
 const isCockpitMode = useRouteQuery<string, boolean>('cockpit_mode', 'false', {
   transform: {
     get: (v: string) => v === 'true',
@@ -185,11 +310,75 @@ const configButtons = [
   },
 ]
 
-const getCameras = async () => {
+const applyCameraUi = (ui: CameraUiState) => {
+  uiLoading.value = ui.loading
+  // Keep the last message while fading out — clearing it to the default
+  // ("Applying settings…") mid-transition looks like a glitch.
+  if (ui.loading_message) {
+    uiLoadingMessage.value = ui.loading_message
+  }
+  uiRebooting.value = ui.rebooting
+  errorDialogMessage.value = ui.error_dialog ?? null
+  warningToastMessage.value = ui.warning_toast ?? null
+}
+
+const uiByCamera = new Map<string, CameraUiState>()
+
+const applyCameraState = (body: unknown) => {
+  if (typeof body !== 'object' || body === null) return
+  const data = body as CameraStateEvent
+  if (data.ui) {
+    uiByCamera.set(data.camera_uuid, data.ui)
+    if (data.camera_uuid === selectedCameraUUID.value) {
+      applyCameraUi(data.ui)
+    }
+  }
+}
+
+watch(selectedCameraUUID, (uuid, previousUuid) => {
+  if (previousUuid) {
+    backendClient.unsubscribeCamera(previousUuid)
+  }
+
+  if (!uuid) {
+    uiLoading.value = false
+    uiRebooting.value = false
+    errorDialogMessage.value = null
+    warningToastMessage.value = null
+    return
+  }
+
+  backendClient.subscribeCamera(uuid)
+
+  const ui = uiByCamera.get(uuid)
+  if (ui) {
+    applyCameraUi(ui)
+  } else {
+    uiLoading.value = false
+    uiRebooting.value = false
+    errorDialogMessage.value = null
+    warningToastMessage.value = null
+  }
+})
+
+const dismissErrorDialog = () => {
+  if (selectedCameraUUID.value) {
+    backendClient.dismissUi(selectedCameraUUID.value, 'error_dialog')
+  }
+  errorDialogMessage.value = null
+}
+
+const applyCameraList = (data: unknown) => {
   try {
-    const response = await axios.get(`${backendAPI.value}/camera/list`)
-    const camerasData = validateCameras(response.data)
+    const camerasData = validateCameras(data)
     cameras.value = camerasData
+
+    if (
+      selectedCameraUUID.value
+      && !cameras.value.some((camera) => camera.uuid === selectedCameraUUID.value)
+    ) {
+      selectedCameraUUID.value = null
+    }
 
     if (!selectedCameraUUID.value && cameras.value.length > 0) {
       const foundCamera = desiredCameraUuid.value
@@ -199,7 +388,7 @@ const getCameras = async () => {
       selectedCameraUUID.value = foundCamera ? foundCamera.uuid : cameras.value[0].uuid
     }
   } catch (error) {
-    console.error('Error getting cameras:', error)
+    console.error('Error processing cameras:', error)
   }
 }
 
@@ -227,14 +416,7 @@ const isCamera = (data: unknown): data is Omit<Camera, 'uuid'> => {
     camera.streams !== null &&
     Object.values(camera.streams).every((stream) => typeof stream === 'string')
 
-  return (
-    typeof camera.hostname === 'string' &&
-    typeof camera.credentials === 'object' &&
-    camera.credentials !== null &&
-    typeof (camera.credentials as Record<string, unknown>).username === 'string' &&
-    typeof (camera.credentials as Record<string, unknown>).password === 'string' &&
-    isStreamsValid
-  )
+  return typeof camera.hostname === 'string' && isStreamsValid
 }
 
 const updateLuaScript = (): void => {
@@ -245,7 +427,7 @@ const updateLuaScript = (): void => {
     return
   }
 
-  runAutopilotControl('exportLuaScript', 'Failed to update Lua script', 'Updating Lua script…')
+  runAutopilotControl('exportLuaScript', 'Failed to update Lua script')
 }
 
 const applyRecommendedCameraSettings = (): void => {
@@ -254,7 +436,7 @@ const applyRecommendedCameraSettings = (): void => {
     return
   }
 
-  runCameraControl('setRecommendedCameraSettings', 'Failed to apply recommended camera settings', 'Applying recommended camera settings…')
+  runCameraControl('setRecommendedCameraSettings', 'Failed to apply recommended camera settings')
 }
 
 const rebootCamera = (): void => {
@@ -265,66 +447,143 @@ const rebootCamera = (): void => {
     return
   }
 
-  runCameraControl('restart', 'Failed to reboot camera', 'Rebooting camera…')
+  runCameraControl('restart', 'Failed to reboot camera')
 }
 
-const runAutopilotControl = (action: string, errorMessage: string, loadingMessage: string): void => {
-  if (!selectedCameraUUID.value || menuActionLoading.value) return
+const runAutopilotControl = (action: string, errorMessage: string): void => {
+  if (!selectedCameraUUID.value || uiLoading.value || uiRebooting.value) return
 
-  menuActionMessage.value = loadingMessage
-  const startedAt = startMinLoading(menuActionLoading)
-
-  axios
-    .post(`${backendAPI.value}/autopilot/control`, {
+  backendClient
+    .request('POST', '/autopilot/control', {
       camera_uuid: selectedCameraUUID.value,
       action,
     })
-    .then((response) => {
-      console.log(response)
-      endMinLoading(menuActionLoading, startedAt)
+    .then((data) => {
+      console.log(data)
     })
     .catch((error) => {
-      errorDialogMessage.value = `${errorMessage}: ${formatRequestError(error)}`
-      endMinLoading(menuActionLoading, startedAt, true)
+      console.error(`${errorMessage}: ${formatRequestError(error)}`)
     })
 }
 
-const runCameraControl = (action: string, errorMessage: string, loadingMessage: string): void => {
-  if (!selectedCameraUUID.value || menuActionLoading.value) return
+const runCameraControl = (action: string, errorMessage: string): void => {
+  if (!selectedCameraUUID.value || uiLoading.value || uiRebooting.value) return
 
-  menuActionMessage.value = loadingMessage
-  const startedAt = startMinLoading(menuActionLoading)
-
-  axios
-    .post(`${backendAPI.value}/camera/control`, {
+  backendClient
+    .request('POST', '/camera/control', {
       camera_uuid: selectedCameraUUID.value,
       action,
     })
-    .then((response) => {
-      console.log(response)
-      endMinLoading(menuActionLoading, startedAt)
+    .then((data) => {
+      console.log(data)
     })
     .catch((error) => {
-      errorDialogMessage.value = `${errorMessage}: ${formatRequestError(error)}`
-      endMinLoading(menuActionLoading, startedAt, true)
+      console.error(`${errorMessage}: ${formatRequestError(error)}`)
     })
 }
+
+const applyConnectionStats = (body: unknown) => {
+  if (typeof body !== 'object' || body === null) return
+  connectionStats.value = body as ConnectionStats
+}
+
+const unsubscribeCameraList = backendClient.onEvent('camera/list', applyCameraList)
+const unsubscribeCameraState = backendClient.onEvent('camera/state', applyCameraState)
+const unsubscribeConnectionStats = backendClient.onEvent('connection/stats', applyConnectionStats)
+const unsubscribeTransportError = backendClient.onTransportError((message) => {
+  // Local-only toast; do not call dismissUi (that would clear shared backend warnings).
+  warningToastMessage.value = message
+})
+const unsubscribeConnectionState = backendClient.onConnectionState((state, previousState) => {
+  if (state === 'disconnected' && previousState !== 'disconnected') {
+    disconnectedSince.value = new Date()
+    connectionStats.value = null
+    uiLoading.value = false
+    uiRebooting.value = false
+  }
+  if (state === 'connected') {
+    disconnectedSince.value = null
+  }
+  connectionState.value = state
+})
 
 onMounted(() => {
-  getCameras()
+  backendClient.connect().catch((error) => {
+    console.error('Error connecting to backend:', error)
+  })
+})
 
-  const intervalId = setInterval(() => {
-    getCameras()
+watch(warningToastMessage, (message, _previous, onCleanup) => {
+  if (!message) return
+
+  const cameraUuid = selectedCameraUUID.value
+  const backendOwned =
+    cameraUuid != null && !!uiByCamera.get(cameraUuid)?.warning_toast
+  const timeout = setTimeout(() => {
+    if (backendOwned && cameraUuid) {
+      backendClient.dismissUi(cameraUuid, 'warning_toast')
+    }
+    warningToastMessage.value = null
   }, 5000)
 
-  onUnmounted(() => {
-    clearInterval(intervalId)
-  })
+  onCleanup(() => clearTimeout(timeout))
+})
+
+onUnmounted(() => {
+  if (selectedCameraUUID.value) {
+    backendClient.unsubscribeCamera(selectedCameraUUID.value)
+  }
+  unsubscribeCameraList()
+  unsubscribeCameraState()
+  unsubscribeConnectionStats()
+  unsubscribeTransportError()
+  unsubscribeConnectionState()
 })
 
 
 </script>
 <style scoped>
+.connection-status-wrap {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 12px;
+  cursor: default;
+}
+
+.connection-stats-tooltip {
+  max-width: 280px;
+}
+
+.connection-stats-bandwidth {
+  display: flex;
+  align-items: center;
+}
+
+.connection-stats-label {
+  display: inline-block;
+  min-width: 2.5rem;
+  margin-right: 0.35rem;
+  opacity: 0.7;
+}
+
+.connection-status-icon {
+  opacity: 0.55;
+}
+
+.connection-status-icon--spinning {
+  animation: connection-status-spin 1.5s linear infinite;
+}
+
+@keyframes connection-status-spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .transparent-card {
   background-color: #10101085;
   backdrop-filter: blur(25px);


### PR DESCRIPTION
## Summary
Split from the websockets work: **Switch HomeView to WebSocket client and shared UI overlays**.

Commits in this slice:
- `frontend: src: views: HomeView: Switch to WebSocket client and shared UI overlays`

## Stack
- Part **10/24** of the websockets split (all PRs target `master`)
- Depends on https://github.com/bluerobotics/radcam-manager/pull/210 merging first.
- After the previous stack PR merges: rebase this branch onto `master` and `git push --force-with-lease`
- Intermediate slices may show **red CI** (incomplete stack / missing later fixes). That is expected.
- The batch is only done when tip **[#225](https://github.com/bluerobotics/radcam-manager/pull/225)** (`24/24`) is green after the full merge-rebase dance.

## Test plan
- [ ] HomeView shows shared loading / reboot / error / warning overlays from backend UI state
- [ ] Camera list updates live over WS
- [ ] Selecting a camera subscribes and fills initial state without axios polling
