### PR TITLE
websockets 13/24: Harden camera state concurrency and set_param paths

### DIFF
--- a/backend/libs/autopilot/src/actuators_watch.rs
+++ b/backend/libs/autopilot/src/actuators_watch.rs
@@ -118,6 +118,22 @@ impl EmitGate {
     }
 }
 
+/// Current interest count for the SERVO stream (WS subscribers / bridges).
+pub fn interest_count() -> usize {
+    INTEREST.load(Ordering::SeqCst)
+}
+
+/// Latest actuators state cached on the manager for `camera_uuid`, if any.
+#[instrument(level = "debug")]
+pub async fn cached_actuators_state(camera_uuid: Uuid) -> Option<api::ActuatorsState> {
+    let manager = MANAGER.get()?.read().await;
+    manager
+        .settings
+        .actuators
+        .get(&camera_uuid)
+        .map(|actuators| actuators.state)
+}
+
 /// Subscribe to throttled actuator state updates from the SERVO stream.
 pub fn subscribe() -> broadcast::Receiver<ActuatorsStateUpdate> {
     state_sender().subscribe()

--- a/backend/libs/autopilot/src/actuators_watch.rs
+++ b/backend/libs/autopilot/src/actuators_watch.rs
@@ -34,6 +34,8 @@ static STATE_TX: OnceCell<broadcast::Sender<ActuatorsStateUpdate>> = OnceCell::n
 static WATCHER_STARTED: AtomicBool = AtomicBool::new(false);
 static INTEREST: AtomicUsize = AtomicUsize::new(0);
 static INTEREST_CHANGED: Notify = Notify::const_new();
+/// Millis since UNIX_EPOCH of the last SERVO sample applied to the manager (0 = never).
+static LAST_SERVO_AT_MS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 /// Actuator positions derived from a MAVLink `SERVO_OUTPUT_RAW` sample.
 #[derive(Debug, Clone)]
@@ -111,6 +113,10 @@ impl EmitGate {
             .is_err()
         {
             debug!("No actuators state subscribers");
+            // Do not advance last_emitted: the sample was never delivered and
+            // must be eligible for replay once a receiver attaches.
+            self.pending.insert(camera_uuid, state);
+            return;
         }
         self.last_emitted.insert(camera_uuid, state);
         self.last_emit_at.insert(camera_uuid, now);
@@ -121,6 +127,35 @@ impl EmitGate {
 /// Current interest count for the SERVO stream (WS subscribers / bridges).
 pub fn interest_count() -> usize {
     INTEREST.load(Ordering::SeqCst)
+}
+
+/// Age of the last SERVO sample written into the manager cache, if any.
+pub fn last_servo_age() -> Option<Duration> {
+    let ms = LAST_SERVO_AT_MS.load(Ordering::SeqCst);
+    if ms == 0 {
+        return None;
+    }
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_millis() as u64;
+    Some(Duration::from_millis(now_ms.saturating_sub(ms)))
+}
+
+/// True when the cached actuators state is fresh enough to serve without a one-shot wait.
+pub fn cache_is_fresh() -> bool {
+    last_servo_age().is_some_and(|age| age < STREAM_STALE_AFTER)
+}
+
+fn mark_servo_sample() {
+    if let Ok(duration) = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+        LAST_SERVO_AT_MS.store(duration.as_millis() as u64, Ordering::SeqCst);
+    }
+}
+
+/// Record that actuators.state was refreshed by a one-shot SERVO wait.
+pub(crate) fn mark_servo_from_get_state() {
+    mark_servo_sample();
 }
 
 /// Latest actuators state cached on the manager for `camera_uuid`, if any.
@@ -255,6 +290,7 @@ async fn actuators_watcher() {
                             }
 
                             last_servo_at = Instant::now();
+                            mark_servo_sample();
 
                             let Some(manager) = MANAGER.get() else {
                                 continue;

--- a/backend/libs/autopilot/src/manager/macros.rs
+++ b/backend/libs/autopilot/src/manager/macros.rs
@@ -52,7 +52,10 @@ macro_rules! generate_update_channel_param_function {
                         current_parameters.$field_name = new_value;
                     }
                     Err(error) => {
-                        warn!("Failed setting parameter: {error:?}")
+                        return Err(anyhow::anyhow!(
+                            "Failed setting parameter {}: {error:?}",
+                            stringify!($field_name)
+                        ));
                     }
                 }
             } else {
@@ -120,7 +123,10 @@ macro_rules! generate_update_mount_param_function {
                         has_changed = true;
                     }
                     Err(error) => {
-                        warn!("Failed setting parameter: {error:?}")
+                        return Err(anyhow::anyhow!(
+                            "Failed setting parameter {}: {error:?}",
+                            stringify!($field_name)
+                        ));
                     }
                 }
             } else {

--- a/backend/libs/autopilot/src/manager/mod.rs
+++ b/backend/libs/autopilot/src/manager/mod.rs
@@ -219,11 +219,15 @@ impl Manager {
             self.mavlink.reboot_autopilot().await?;
         }
 
+        // Re-push ENABLE/GAIN only when the Lua script was rewritten/reloaded (or a
+        // full overwrite/reboot), so a correlation toggle does not force a GAIN
+        // round-trip under the manager write lock.
+        let force_script_params = reload_script || overwrite || autopilot_reboot_required;
         if let Some(parameters) = &new_config.parameters {
-            self.update_script_enable(camera_uuid, parameters, true)
+            self.update_script_enable(camera_uuid, parameters, force_script_params)
                 .await?;
 
-            self.update_script_gain(camera_uuid, parameters, true)
+            self.update_script_gain(camera_uuid, parameters, force_script_params)
                 .await?;
         }
 

--- a/backend/libs/autopilot/src/manager/mod.rs
+++ b/backend/libs/autopilot/src/manager/mod.rs
@@ -95,6 +95,7 @@ impl Manager {
 
         let state = actuators_state_from_servo(actuators, &servo_output_raw);
         actuators.state = state;
+        crate::actuators_watch::mark_servo_from_get_state();
 
         Ok(actuators.state)
     }
@@ -108,6 +109,10 @@ impl Manager {
         use ::mavlink::ardupilotmega::{COMMAND_LONG_DATA, CameraZoomType, MavCmd, SetFocusType};
 
         let focus_was_set = new_state.focus.is_some();
+
+        if new_state.tilt.is_some() && new_state.focus.is_none() && new_state.zoom.is_none() {
+            return Err(anyhow::anyhow!("Tilt setpoint is not implemented"));
+        }
 
         if let Some(focus) = new_state.focus {
             self.mavlink

--- a/backend/libs/autopilot/src/manager/mod.rs
+++ b/backend/libs/autopilot/src/manager/mod.rs
@@ -151,12 +151,11 @@ impl Manager {
                 Ok(measured)
             }
             Err(error) => {
-                debug!("Failed reading actuators after set: {error:?}");
                 if focus_was_set {
                     self.check_focus_script_health(camera_uuid).await;
                 }
-                // Fall back so the UI stays responsive when the SERVO stream is quiet.
-                Ok(*new_state)
+                // Do not fall back to the unverified setpoint — that lied to the UI.
+                Err(error)
             }
         }
     }

--- a/backend/libs/autopilot/src/manager/script.rs
+++ b/backend/libs/autopilot/src/manager/script.rs
@@ -189,8 +189,6 @@ impl Manager {
             .or_default()
             .parameters;
 
-        let encoding = self.mavlink.encoding().await;
-
         let channel = current_parameters.camera_id as u8;
 
         let param_name = format!("{PARAM_PREFIX}{channel}_ENABLE");
@@ -201,29 +199,31 @@ impl Manager {
             (None, false) => return Ok(()),
         };
 
-        let mut param = self.mavlink.get_param(&param_name, false).await?;
         let old_value = current_parameters.enable_focus_and_zoom_correlation;
+        if !force_apply && old_value == new_value {
+            trace!("Parameter {param_name:?} skipped");
+            return Ok(());
+        }
+
+        let encoding = self.mavlink.encoding().await;
+        let mut param = self.mavlink.get_param(&param_name, false).await?;
         param
             .value
             .set_value(ParamType::UINT8(new_value as u8), encoding)?;
 
-        if (old_value != new_value) || force_apply {
-            match self.mavlink.set_param(param).await {
-                Ok(_) => {
-                    if old_value != new_value {
-                        info!(
-                            "{} changed from {old_value:?} to {new_value:?}",
-                            stringify!(enable_focus_and_zoom_correlation),
-                        );
-                    }
-                    current_parameters.enable_focus_and_zoom_correlation = new_value;
+        match self.mavlink.set_param(param).await {
+            Ok(_) => {
+                if old_value != new_value {
+                    info!(
+                        "{} changed from {old_value:?} to {new_value:?}",
+                        stringify!(enable_focus_and_zoom_correlation),
+                    );
                 }
-                Err(error) => {
-                    warn!("Failed setting parameter: {error:?}")
-                }
+                current_parameters.enable_focus_and_zoom_correlation = new_value;
             }
-        } else {
-            trace!("Parameter {param_name:?} skipped");
+            Err(error) => {
+                warn!("Failed setting parameter: {error:?}")
+            }
         }
 
         Ok(())
@@ -242,8 +242,6 @@ impl Manager {
             .or_default()
             .parameters;
 
-        let encoding = self.mavlink.encoding().await;
-
         let channel = current_parameters.camera_id as u8;
 
         let param_name = format!("{PARAM_PREFIX}{channel}_GAIN");
@@ -254,29 +252,31 @@ impl Manager {
             (None, false) => return Ok(()),
         };
 
-        let mut param = self.mavlink.get_param(&param_name, false).await?;
         let old_value = current_parameters.focus_margin_gain;
+        if !force_apply && old_value == new_value {
+            trace!("Parameter {param_name:?} skipped");
+            return Ok(());
+        }
+
+        let encoding = self.mavlink.encoding().await;
+        let mut param = self.mavlink.get_param(&param_name, false).await?;
         param
             .value
             .set_value(ParamType::UINT8(new_value as u8), encoding)?;
 
-        if (old_value != new_value) || force_apply {
-            match self.mavlink.set_param(param).await {
-                Ok(_) => {
-                    if old_value != new_value {
-                        info!(
-                            "{} changed from {old_value:?} to {new_value:?}",
-                            stringify!(focus_margin_gain),
-                        );
-                    }
-                    current_parameters.focus_margin_gain = new_value;
+        match self.mavlink.set_param(param).await {
+            Ok(_) => {
+                if old_value != new_value {
+                    info!(
+                        "{} changed from {old_value:?} to {new_value:?}",
+                        stringify!(focus_margin_gain),
+                    );
                 }
-                Err(error) => {
-                    warn!("Failed setting parameter: {error:?}")
-                }
+                current_parameters.focus_margin_gain = new_value;
             }
-        } else {
-            trace!("Parameter {param_name:?} skipped");
+            Err(error) => {
+                warn!("Failed setting parameter: {error:?}")
+            }
         }
 
         Ok(())

--- a/backend/libs/autopilot/src/manager/script.rs
+++ b/backend/libs/autopilot/src/manager/script.rs
@@ -222,7 +222,7 @@ impl Manager {
                 current_parameters.enable_focus_and_zoom_correlation = new_value;
             }
             Err(error) => {
-                warn!("Failed setting parameter: {error:?}")
+                return Err(error).context(format!("Failed setting parameter {param_name}"));
             }
         }
 
@@ -275,7 +275,7 @@ impl Manager {
                 current_parameters.focus_margin_gain = new_value;
             }
             Err(error) => {
-                warn!("Failed setting parameter: {error:?}")
+                return Err(error).context(format!("Failed setting parameter {param_name}"));
             }
         }
 
@@ -347,12 +347,12 @@ impl Manager {
         let script_output_raw =
             get_output_raw_from_channel(&servo_output_raw, actuators.parameters.focus_channel);
 
-        if let (Some(input_raw), Some(output_raw)) = (script_input_raw, script_output_raw) {
-            if self.script_health.update(input_raw, output_raw) {
-                warn!("Attempting Lua script reload due to stale focus output");
-                if let Err(error) = self.mavlink.reload_lua_scripts(true).await {
-                    error!("Failed to reload Lua scripts: {error:?}");
-                }
+        if let (Some(input_raw), Some(output_raw)) = (script_input_raw, script_output_raw)
+            && self.script_health.update(input_raw, output_raw)
+        {
+            warn!("Attempting Lua script reload due to stale focus output");
+            if let Err(error) = self.mavlink.reload_lua_scripts(true).await {
+                error!("Failed to reload Lua scripts: {error:?}");
             }
         }
     }

--- a/backend/libs/autopilot/src/mavlink/parameters.rs
+++ b/backend/libs/autopilot/src/mavlink/parameters.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use indexmap::IndexMap;
 use mavlink::{
     MavHeader,
@@ -443,9 +443,11 @@ impl MavlinkComponent {
             let recv_parameter = match Self::wait_for_param(inner.clone(), &parameter.name).await {
                 Ok(parameter) => parameter,
                 Err(error) => {
-                    warn!("Failed getting parameter: {error:?}");
-
-                    continue;
+                    // wait_for_param already exhausted its retries; do not loop
+                    // forever here (that held MANAGER.write() for tens of seconds).
+                    let name = &parameter.name;
+                    return Err(error)
+                        .context(format!("Failed confirming parameter {name} after set"));
                 }
             };
 

--- a/backend/libs/autopilot/src/mavlink/parameters.rs
+++ b/backend/libs/autopilot/src/mavlink/parameters.rs
@@ -432,8 +432,16 @@ impl MavlinkComponent {
             param_type: parameter.param_type(),
         });
 
+        let mut send_retries = 5;
         loop {
             if let Err(error) = sender.send(Message::ToBeSent((header, message.clone()))) {
+                send_retries -= 1;
+                if send_retries == 0 {
+                    return Err(anyhow!(
+                        "Failed requesting parameter {}: {error:?}",
+                        parameter.name
+                    ));
+                }
                 warn!("Failed requesting parameter: {error:?}");
 
                 tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
@@ -455,9 +463,8 @@ impl MavlinkComponent {
                 recv_parameter.param_value(encoding),
                 parameter.param_value(encoding),
             ) else {
-                warn!("Failed checking param!");
-
-                continue;
+                let name = &parameter.name;
+                return Err(anyhow!("Failed checking param values for {name} after set"));
             };
 
             if recv_value != sent_value {

--- a/backend/libs/autopilot/src/mod.rs
+++ b/backend/libs/autopilot/src/mod.rs
@@ -83,11 +83,17 @@ pub(crate) async fn control_inner(
             serde_json::to_value({})?
         }
         Action::GetActuatorsState => {
-            let mut manager = MANAGER.get().context("Not available")?.write().await;
+            // Read cached state under a shared lock so we do not block the SERVO
+            // watcher (which needs write) for a one-shot MAVLink wait.
+            let manager = MANAGER.get().context("Not available")?.read().await;
 
-            let state = manager.get_state(&actuators_control.camera_uuid).await?;
+            let actuators = manager
+                .settings
+                .actuators
+                .get(&actuators_control.camera_uuid)
+                .context(crate::ACTUATORS_NOT_CONFIGURED)?;
 
-            serde_json::to_value(state)?
+            serde_json::to_value(actuators.state)?
         }
         Action::SetActuatorsState(new_state) => {
             let mut manager = MANAGER.get().context("Not available")?.write().await;

--- a/backend/libs/autopilot/src/mod.rs
+++ b/backend/libs/autopilot/src/mod.rs
@@ -11,9 +11,9 @@ use serde::{Deserialize, Serialize};
 use tracing::*;
 
 pub use actuators_watch::{
-    add_interest as add_actuators_state_interest,
-    remove_interest as remove_actuators_state_interest, shutdown as shutdown_actuators_stream,
-    subscribe as subscribe_actuators_state,
+    add_interest as add_actuators_state_interest, cached_actuators_state,
+    interest_count as actuators_interest_count, remove_interest as remove_actuators_state_interest,
+    shutdown as shutdown_actuators_stream, subscribe as subscribe_actuators_state,
 };
 pub use manager::{clear_saved_settings, init};
 
@@ -83,17 +83,24 @@ pub(crate) async fn control_inner(
             serde_json::to_value({})?
         }
         Action::GetActuatorsState => {
-            // Read cached state under a shared lock so we do not block the SERVO
-            // watcher (which needs write) for a one-shot MAVLink wait.
-            let manager = MANAGER.get().context("Not available")?.read().await;
+            // Prefer the SERVO watcher's cache under a shared lock when the stream
+            // is active. With no interest, fall back to a one-shot SERVO wait so
+            // REST callers still get measured positions.
+            if actuators_watch::interest_count() > 0 {
+                let manager = MANAGER.get().context("Not available")?.read().await;
 
-            let actuators = manager
-                .settings
-                .actuators
-                .get(&actuators_control.camera_uuid)
-                .context(crate::ACTUATORS_NOT_CONFIGURED)?;
+                let actuators = manager
+                    .settings
+                    .actuators
+                    .get(&actuators_control.camera_uuid)
+                    .context(crate::ACTUATORS_NOT_CONFIGURED)?;
 
-            serde_json::to_value(actuators.state)?
+                serde_json::to_value(actuators.state)?
+            } else {
+                let mut manager = MANAGER.get().context("Not available")?.write().await;
+                let state = manager.get_state(&actuators_control.camera_uuid).await?;
+                serde_json::to_value(state)?
+            }
         }
         Action::SetActuatorsState(new_state) => {
             let mut manager = MANAGER.get().context("Not available")?.write().await;

--- a/backend/libs/autopilot/src/mod.rs
+++ b/backend/libs/autopilot/src/mod.rs
@@ -11,9 +11,10 @@ use serde::{Deserialize, Serialize};
 use tracing::*;
 
 pub use actuators_watch::{
-    add_interest as add_actuators_state_interest, cached_actuators_state,
-    interest_count as actuators_interest_count, remove_interest as remove_actuators_state_interest,
-    shutdown as shutdown_actuators_stream, subscribe as subscribe_actuators_state,
+    add_interest as add_actuators_state_interest, cache_is_fresh as actuators_cache_is_fresh,
+    cached_actuators_state, interest_count as actuators_interest_count,
+    remove_interest as remove_actuators_state_interest, shutdown as shutdown_actuators_stream,
+    subscribe as subscribe_actuators_state,
 };
 pub use manager::{clear_saved_settings, init};
 
@@ -83,10 +84,10 @@ pub(crate) async fn control_inner(
             serde_json::to_value({})?
         }
         Action::GetActuatorsState => {
-            // Prefer the SERVO watcher's cache under a shared lock when the stream
-            // is active. With no interest, fall back to a one-shot SERVO wait so
-            // REST callers still get measured positions.
-            if actuators_watch::interest_count() > 0 {
+            // Prefer the SERVO watcher's cache when interest is on *and* a recent
+            // sample exists. Otherwise one-shot wait so subscribe/REST are not
+            // served stale defaults from disk.
+            if actuators_watch::interest_count() > 0 && actuators_watch::cache_is_fresh() {
                 let manager = MANAGER.get().context("Not available")?.read().await;
 
                 let actuators = manager

--- a/backend/libs/radcam_manager/src/web/camera_state.rs
+++ b/backend/libs/radcam_manager/src/web/camera_state.rs
@@ -72,6 +72,20 @@ pub(crate) fn emit_ui(camera_uuid: Uuid, ui: CameraUiState) {
     });
 }
 
+/// Broadcast without writing `event` into the cache.
+///
+/// Use after [`commit_fetched_snapshot`]: the cache is already authoritative, and
+/// re-recording would clobber concurrent `record_partial` updates.
+#[instrument(level = "debug", skip_all, fields(%event.camera_uuid))]
+fn broadcast_event(event: CameraStateEvent) {
+    if !has_interest(event.camera_uuid) {
+        return;
+    }
+    if let Err(error) = state_sender().send(event) {
+        debug!("No camera state subscribers: {error}");
+    }
+}
+
 /// Returns true when `connection_id` is subscribed to `camera_uuid`.
 pub(crate) fn connection_subscribed(connection_id: ConnectionId, camera_uuid: Uuid) -> bool {
     registry()
@@ -224,10 +238,20 @@ pub(crate) fn emit_camera_control_update(
             }
             event.video_parameters = Some(result.clone());
         }
-        CameraAction::SetRecommendedCameraSettings
-        | CameraAction::Restart
-        | CameraAction::SetImageAdjustmentExAll(_) => {
+        CameraAction::SetRecommendedCameraSettings | CameraAction::Restart => {
             tokio::spawn(reconcile_snapshot(camera_uuid).instrument(Span::current()));
+            return;
+        }
+        CameraAction::SetImageAdjustmentExAll(_) => {
+            // Applies to every camera; refresh all that currently have subscribers.
+            let cameras: Vec<Uuid> = {
+                let registry = registry().lock().unwrap();
+                registry.camera_interest.keys().copied().collect()
+            };
+            let span = Span::current();
+            for uuid in cameras {
+                tokio::spawn(reconcile_snapshot(uuid).instrument(span.clone()));
+            }
             return;
         }
         _ => return,
@@ -261,6 +285,9 @@ pub(crate) fn emit_autopilot_control_update(
 }
 
 /// Re-fetch and emit changed camera fields after disruptive actions.
+///
+/// Does not refresh `actuators_state` (SERVO bridge owns that) and broadcasts
+/// without re-recording so concurrent partial updates are not clobbered.
 #[instrument(level = "debug")]
 pub(crate) async fn reconcile_snapshot(camera_uuid: Uuid) {
     if !has_interest(camera_uuid) {
@@ -268,7 +295,7 @@ pub(crate) async fn reconcile_snapshot(camera_uuid: Uuid) {
     }
 
     let baseline = last_state(camera_uuid);
-    let fetched = fetch_snapshot(camera_uuid, &baseline).await;
+    let fetched = fetch_slow_snapshot(camera_uuid, &baseline).await;
     if fetched == baseline {
         return;
     }
@@ -276,8 +303,40 @@ pub(crate) async fn reconcile_snapshot(camera_uuid: Uuid) {
     let Some(merged) = commit_fetched_snapshot(camera_uuid, &baseline, fetched) else {
         return;
     };
+    if merged == baseline {
+        return;
+    }
 
-    emit(snapshot_to_event(camera_uuid, merged, None));
+    let event = CameraStateEvent {
+        camera_uuid,
+        actuators_config: (merged.actuators_config != baseline.actuators_config)
+            .then(|| merged.actuators_config.clone())
+            .flatten(),
+        actuators_configured: (merged.actuators_configured != baseline.actuators_configured)
+            .then_some(merged.actuators_configured)
+            .flatten(),
+        video_parameters: (merged.video_parameters != baseline.video_parameters)
+            .then(|| merged.video_parameters.clone())
+            .flatten(),
+        base_parameters: (merged.base_parameters != baseline.base_parameters)
+            .then(|| merged.base_parameters.clone())
+            .flatten(),
+        advanced_parameters: (merged.advanced_parameters != baseline.advanced_parameters)
+            .then(|| merged.advanced_parameters.clone())
+            .flatten(),
+        ..Default::default()
+    };
+
+    if event.actuators_config.is_none()
+        && event.actuators_configured.is_none()
+        && event.video_parameters.is_none()
+        && event.base_parameters.is_none()
+        && event.advanced_parameters.is_none()
+    {
+        return;
+    }
+
+    broadcast_event(event);
 }
 
 /// Apply `fetched` into the cache for fields that were not updated concurrently since
@@ -381,6 +440,10 @@ fn state_sender() -> &'static broadcast::Sender<CameraStateEvent> {
 #[instrument(level = "debug", skip_all, fields(%event.camera_uuid))]
 fn emit(mut event: CameraStateEvent) {
     record_partial(&mut event);
+    // record_partial is a no-op without interest; skip waking every WS filter.
+    if !has_interest(event.camera_uuid) {
+        return;
+    }
     if let Err(error) = state_sender().send(event) {
         debug!("No camera state subscribers: {error}");
     }
@@ -466,7 +529,8 @@ fn ensure_actuators_bridge() {
                     break;
                 }
                 Err(broadcast::error::RecvError::Lagged(samples)) => {
-                    debug!("Actuators bridge lagged by {samples} updates");
+                    debug!("Actuators bridge lagged by {samples} updates; re-pushing cache");
+                    resync_actuators_from_cache();
                 }
             }
         }
@@ -593,6 +657,7 @@ async fn slow_state_watcher() {
 
             // Emit only fields that differ from the pre-fetch baseline, using the merged
             // cache values so concurrent record_partial updates are what clients see.
+            // Broadcast without re-recording: commit already wrote the cache.
             let event = CameraStateEvent {
                 camera_uuid,
                 actuators_config: (merged.actuators_config != previous.actuators_config)
@@ -625,8 +690,37 @@ async fn slow_state_watcher() {
                 continue;
             }
 
-            emit(event);
+            broadcast_event(event);
         }
+    }
+}
+
+/// Re-push cached `actuators_state` after the SERVO broadcast lagged.
+#[instrument(level = "debug", skip_all)]
+fn resync_actuators_from_cache() {
+    let events: Vec<CameraStateEvent> = {
+        let registry = registry().lock().unwrap();
+        registry
+            .camera_interest
+            .keys()
+            .filter_map(|camera_uuid| {
+                let actuators_state = registry
+                    .last_states
+                    .get(camera_uuid)?
+                    .actuators_state
+                    .clone()?;
+                Some(CameraStateEvent {
+                    camera_uuid: *camera_uuid,
+                    actuators_state: Some(actuators_state),
+                    ..Default::default()
+                })
+            })
+            .collect()
+    };
+
+    for event in events {
+        // Re-record is fine: values match cache; clients need a fresh push after lag.
+        emit(event);
     }
 }
 

--- a/backend/libs/radcam_manager/src/web/camera_state.rs
+++ b/backend/libs/radcam_manager/src/web/camera_state.rs
@@ -35,6 +35,7 @@ const MAX_CAMERAS_PER_CONNECTION: usize = 8;
 static ACTUATORS_BRIDGE_STARTED: AtomicBool = AtomicBool::new(false);
 static SLOW_WATCHER_STARTED: AtomicBool = AtomicBool::new(false);
 static CAMERA_LIST_WATCHER_STARTED: AtomicBool = AtomicBool::new(false);
+static ACTUATORS_LAG_RESYNCING: AtomicBool = AtomicBool::new(false);
 static REGISTRY: OnceCell<Mutex<Registry>> = OnceCell::new();
 static STATE_TX: OnceCell<broadcast::Sender<CameraStateEvent>> = OnceCell::new();
 static ACTUATORS_DEFAULT_CONFIG: tokio::sync::OnceCell<serde_json::Value> =
@@ -206,15 +207,19 @@ pub(crate) fn cached_state_event(camera_uuid: Uuid) -> CameraStateEvent {
 }
 
 /// Actuators-only event from the autopilot manager cache (for lag recovery).
+///
+/// Updates `last_states` so remounts see the same positions.
 #[instrument(level = "debug", skip_all, fields(%camera_uuid))]
 pub(crate) async fn actuators_state_event(camera_uuid: Uuid) -> Option<CameraStateEvent> {
     let state = autopilot::cached_actuators_state(camera_uuid).await?;
     let actuators_state = serde_json::to_value(state).ok()?;
-    Some(CameraStateEvent {
+    let mut event = CameraStateEvent {
         camera_uuid,
         actuators_state: Some(actuators_state),
         ..Default::default()
-    })
+    };
+    record_partial(&mut event);
+    Some(event)
 }
 
 /// Fetch a full camera snapshot for initial subscribe / lag recovery.
@@ -542,12 +547,19 @@ fn ensure_actuators_bridge() {
                 }
                 Err(broadcast::error::RecvError::Lagged(samples)) => {
                     debug!("Actuators bridge lagged by {samples} updates; re-pushing from manager");
+                    if ACTUATORS_LAG_RESYNCING
+                        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                        .is_err()
+                    {
+                        continue;
+                    }
                     let cameras: Vec<Uuid> = {
                         let registry = registry().lock().unwrap();
                         registry.camera_interest.keys().copied().collect()
                     };
                     tokio::spawn(async move {
                         resync_actuators_from_manager(cameras).await;
+                        ACTUATORS_LAG_RESYNCING.store(false, Ordering::SeqCst);
                     });
                 }
             }
@@ -747,6 +759,8 @@ fn snapshot_to_event(
     snapshot: CameraSnapshot,
     actuators_default_config: Option<serde_json::Value>,
 ) -> CameraStateEvent {
+    // Omit ui: live dismissals must not be overwritten by a long-running snapshot.
+    // Subscribe pushes UI separately before the snapshot.
     CameraStateEvent {
         camera_uuid,
         actuators_default_config,
@@ -756,7 +770,7 @@ fn snapshot_to_event(
         video_parameters: snapshot.video_parameters,
         base_parameters: snapshot.base_parameters,
         advanced_parameters: snapshot.advanced_parameters,
-        ui: Some(camera_ui::get(camera_uuid)),
+        ui: None,
     }
 }
 

--- a/backend/libs/radcam_manager/src/web/camera_state.rs
+++ b/backend/libs/radcam_manager/src/web/camera_state.rs
@@ -205,6 +205,18 @@ pub(crate) fn cached_state_event(camera_uuid: Uuid) -> CameraStateEvent {
     )
 }
 
+/// Actuators-only event from the autopilot manager cache (for lag recovery).
+#[instrument(level = "debug", skip_all, fields(%camera_uuid))]
+pub(crate) async fn actuators_state_event(camera_uuid: Uuid) -> Option<CameraStateEvent> {
+    let state = autopilot::cached_actuators_state(camera_uuid).await?;
+    let actuators_state = serde_json::to_value(state).ok()?;
+    Some(CameraStateEvent {
+        camera_uuid,
+        actuators_state: Some(actuators_state),
+        ..Default::default()
+    })
+}
+
 /// Fetch a full camera snapshot for initial subscribe / lag recovery.
 #[instrument(level = "debug", skip_all, fields(%camera_uuid))]
 pub(crate) async fn snapshot(camera_uuid: Uuid) -> CameraStateEvent {
@@ -529,8 +541,14 @@ fn ensure_actuators_bridge() {
                     break;
                 }
                 Err(broadcast::error::RecvError::Lagged(samples)) => {
-                    debug!("Actuators bridge lagged by {samples} updates; re-pushing cache");
-                    resync_actuators_from_cache();
+                    debug!("Actuators bridge lagged by {samples} updates; re-pushing from manager");
+                    let cameras: Vec<Uuid> = {
+                        let registry = registry().lock().unwrap();
+                        registry.camera_interest.keys().copied().collect()
+                    };
+                    tokio::spawn(async move {
+                        resync_actuators_from_manager(cameras).await;
+                    });
                 }
             }
         }
@@ -695,32 +713,32 @@ async fn slow_state_watcher() {
     }
 }
 
-/// Re-push cached `actuators_state` after the SERVO broadcast lagged.
+/// Re-push manager-cached actuators after the SERVO broadcast lagged.
+///
+/// Uses the autopilot manager (authoritative after the watcher wrote it), not
+/// this module's possibly-stale `last_states`, so EmitGate-deduped positions
+/// still reach clients.
 #[instrument(level = "debug", skip_all)]
-fn resync_actuators_from_cache() {
-    let events: Vec<CameraStateEvent> = {
-        let registry = registry().lock().unwrap();
-        registry
-            .camera_interest
-            .keys()
-            .filter_map(|camera_uuid| {
-                let actuators_state = registry
-                    .last_states
-                    .get(camera_uuid)?
-                    .actuators_state
-                    .clone()?;
-                Some(CameraStateEvent {
-                    camera_uuid: *camera_uuid,
-                    actuators_state: Some(actuators_state),
-                    ..Default::default()
-                })
-            })
-            .collect()
-    };
-
-    for event in events {
-        // Re-record is fine: values match cache; clients need a fresh push after lag.
-        emit(event);
+async fn resync_actuators_from_manager(cameras: Vec<Uuid>) {
+    for camera_uuid in cameras {
+        if !has_interest(camera_uuid) {
+            continue;
+        }
+        let Some(state) = autopilot::cached_actuators_state(camera_uuid).await else {
+            continue;
+        };
+        let actuators_state = match serde_json::to_value(state) {
+            Ok(value) => value,
+            Err(error) => {
+                warn!("Failed serializing actuators state: {error}");
+                continue;
+            }
+        };
+        emit(CameraStateEvent {
+            camera_uuid,
+            actuators_state: Some(actuators_state),
+            ..Default::default()
+        });
     }
 }
 

--- a/backend/libs/radcam_manager/src/web/control_bridge.rs
+++ b/backend/libs/radcam_manager/src/web/control_bridge.rs
@@ -7,12 +7,15 @@ use serde_json::Value;
 
 use crate::web::{camera_state, camera_ui};
 
+/// Wire / HTTP body when the requested camera UUID is not in the MCM list.
+pub(crate) const UNKNOWN_CAMERA: &str = "unknown camera";
+
 /// Run a camera control, driving the shared UI overlay and state stream.
 #[tracing::instrument(level = "debug", skip_all, fields(%camera_control.camera_uuid))]
 pub(crate) async fn camera_control(camera_control: CameraControl) -> Result<Value, String> {
     let camera_uuid = camera_control.camera_uuid;
     if mcm_client::get_camera(&camera_uuid).await.is_none() {
-        return Err("unknown camera".to_string());
+        return Err(UNKNOWN_CAMERA.to_string());
     }
     let action = camera_control.action.clone();
     camera_ui::start_camera_action(camera_uuid, &action);
@@ -38,7 +41,7 @@ pub(crate) async fn autopilot_control(
 ) -> Result<Value, String> {
     let camera_uuid = actuators_control.camera_uuid;
     if mcm_client::get_camera(&camera_uuid).await.is_none() {
-        return Err("unknown camera".to_string());
+        return Err(UNKNOWN_CAMERA.to_string());
     }
     let action = actuators_control.action.clone();
     camera_ui::start_autopilot_action(camera_uuid, &action);
@@ -55,4 +58,9 @@ pub(crate) async fn autopilot_control(
             Err(error)
         }
     }
+}
+
+/// Map a control-bridge error string to an HTTP / WS status code.
+pub(crate) fn status_for_error(error: &str) -> u16 {
+    if error == UNKNOWN_CAMERA { 404 } else { 500 }
 }

--- a/backend/libs/radcam_manager/src/web/control_bridge.rs
+++ b/backend/libs/radcam_manager/src/web/control_bridge.rs
@@ -10,12 +10,35 @@ use crate::web::{camera_state, camera_ui};
 /// Wire / HTTP body when the requested camera UUID is not in the MCM list.
 pub(crate) const UNKNOWN_CAMERA: &str = "unknown camera";
 
+/// Failed control with an HTTP/WS status already chosen (avoids stringly 404 matching).
+#[derive(Debug)]
+pub(crate) struct ControlError {
+    pub status: u16,
+    pub message: String,
+}
+
+impl ControlError {
+    fn unknown_camera() -> Self {
+        Self {
+            status: 404,
+            message: UNKNOWN_CAMERA.to_string(),
+        }
+    }
+
+    fn other(message: String) -> Self {
+        Self {
+            status: 500,
+            message,
+        }
+    }
+}
+
 /// Run a camera control, driving the shared UI overlay and state stream.
 #[tracing::instrument(level = "debug", skip_all, fields(%camera_control.camera_uuid))]
-pub(crate) async fn camera_control(camera_control: CameraControl) -> Result<Value, String> {
+pub(crate) async fn camera_control(camera_control: CameraControl) -> Result<Value, ControlError> {
     let camera_uuid = camera_control.camera_uuid;
     if mcm_client::get_camera(&camera_uuid).await.is_none() {
-        return Err(UNKNOWN_CAMERA.to_string());
+        return Err(ControlError::unknown_camera());
     }
     let action = camera_control.action.clone();
     camera_ui::start_camera_action(camera_uuid, &action);
@@ -27,9 +50,9 @@ pub(crate) async fn camera_control(camera_control: CameraControl) -> Result<Valu
             Ok(value)
         }
         Err(error) => {
-            let error = format!("{error:?}");
-            camera_ui::fail_camera_action(camera_uuid, &action, &error);
-            Err(error)
+            let message = format!("{error:?}");
+            camera_ui::fail_camera_action(camera_uuid, &action, &message);
+            Err(ControlError::other(message))
         }
     }
 }
@@ -38,10 +61,10 @@ pub(crate) async fn camera_control(camera_control: CameraControl) -> Result<Valu
 #[tracing::instrument(level = "debug", skip_all, fields(%actuators_control.camera_uuid))]
 pub(crate) async fn autopilot_control(
     actuators_control: ActuatorsControl,
-) -> Result<Value, String> {
+) -> Result<Value, ControlError> {
     let camera_uuid = actuators_control.camera_uuid;
     if mcm_client::get_camera(&camera_uuid).await.is_none() {
-        return Err(UNKNOWN_CAMERA.to_string());
+        return Err(ControlError::unknown_camera());
     }
     let action = actuators_control.action.clone();
     camera_ui::start_autopilot_action(camera_uuid, &action);
@@ -53,14 +76,9 @@ pub(crate) async fn autopilot_control(
             Ok(value)
         }
         Err(error) => {
-            let error = format!("{error:?}");
-            camera_ui::fail_autopilot_action(camera_uuid, &action, &error);
-            Err(error)
+            let message = format!("{error:?}");
+            camera_ui::fail_autopilot_action(camera_uuid, &action, &message);
+            Err(ControlError::other(message))
         }
     }
-}
-
-/// Map a control-bridge error string to an HTTP / WS status code.
-pub(crate) fn status_for_error(error: &str) -> u16 {
-    if error == UNKNOWN_CAMERA { 404 } else { 500 }
 }

--- a/backend/libs/radcam_manager/src/web/routes/v1/camera/mod.rs
+++ b/backend/libs/radcam_manager/src/web/routes/v1/camera/mod.rs
@@ -24,9 +24,9 @@ async fn control(Json(camera_control): Json<CameraControl>) -> impl IntoResponse
     match control_bridge::camera_control(camera_control).await {
         Ok(value) => (StatusCode::OK, value.to_string()).into_response(),
         Err(error) => {
-            let status = StatusCode::from_u16(control_bridge::status_for_error(&error))
-                .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-            (status, error).into_response()
+            let status =
+                StatusCode::from_u16(error.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+            (status, error.message).into_response()
         }
     }
 }

--- a/backend/libs/radcam_manager/src/web/routes/v1/camera/mod.rs
+++ b/backend/libs/radcam_manager/src/web/routes/v1/camera/mod.rs
@@ -23,6 +23,10 @@ pub fn router() -> Router {
 async fn control(Json(camera_control): Json<CameraControl>) -> impl IntoResponse {
     match control_bridge::camera_control(camera_control).await {
         Ok(value) => (StatusCode::OK, value.to_string()).into_response(),
-        Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error).into_response(),
+        Err(error) => {
+            let status = StatusCode::from_u16(control_bridge::status_for_error(&error))
+                .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+            (status, error).into_response()
+        }
     }
 }

--- a/backend/libs/radcam_manager/src/web/routes/v1/mod.rs
+++ b/backend/libs/radcam_manager/src/web/routes/v1/mod.rs
@@ -42,9 +42,9 @@ async fn autopilot_control(Json(actuators_control): Json<ActuatorsControl>) -> i
     match control_bridge::autopilot_control(actuators_control).await {
         Ok(value) => (StatusCode::OK, value.to_string()).into_response(),
         Err(error) => {
-            let status = StatusCode::from_u16(control_bridge::status_for_error(&error))
-                .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-            (status, error).into_response()
+            let status =
+                StatusCode::from_u16(error.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+            (status, error.message).into_response()
         }
     }
 }

--- a/backend/libs/radcam_manager/src/web/routes/v1/mod.rs
+++ b/backend/libs/radcam_manager/src/web/routes/v1/mod.rs
@@ -41,7 +41,11 @@ pub fn router() -> Router {
 async fn autopilot_control(Json(actuators_control): Json<ActuatorsControl>) -> impl IntoResponse {
     match control_bridge::autopilot_control(actuators_control).await {
         Ok(value) => (StatusCode::OK, value.to_string()).into_response(),
-        Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error).into_response(),
+        Err(error) => {
+            let status = StatusCode::from_u16(control_bridge::status_for_error(&error))
+                .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+            (status, error).into_response()
+        }
     }
 }
 

--- a/backend/libs/radcam_manager/src/web/routes/v1/ws.rs
+++ b/backend/libs/radcam_manager/src/web/routes/v1/ws.rs
@@ -348,9 +348,15 @@ async fn handle_client_text(
                 }
 
                 // Never park on the permit — subscribe/unsubscribe churn must not pile up
-                // tasks. The slow watcher fills in if the initial snapshot is skipped.
+                // tasks. The slow watcher fills params; actuators need an explicit push.
                 let Ok(permit) = snapshot_permits.clone().try_acquire_owned() else {
-                    debug!(%connection_id, %camera_uuid, "No permit for subscribe snapshot");
+                    debug!(%connection_id, %camera_uuid, "No permit for subscribe snapshot; pushing actuators only");
+                    if let Some(event) = camera_state::actuators_state_event(camera_uuid).await
+                        && let Some(text) = state_event_text(&event)
+                    {
+                        // close_notify already woken on Full; nothing left to unwind here.
+                        let _ = queue_text(connection_id, response_tx, close_notify, text);
+                    }
                     return;
                 };
 

--- a/backend/libs/radcam_manager/src/web/routes/v1/ws.rs
+++ b/backend/libs/radcam_manager/src/web/routes/v1/ws.rs
@@ -291,6 +291,7 @@ async fn handle_client_text(
             WsClientMessage::Subscribe { camera_uuid } => {
                 if mcm_client::get_camera(&camera_uuid).await.is_none() {
                     warn!(%connection_id, %camera_uuid, "Rejecting subscribe for unknown camera");
+                    // close_notify already woken on Full; read loop exits via the notify arm.
                     let _ = queue_subscribe_rejected(
                         connection_id,
                         response_tx,
@@ -305,6 +306,7 @@ async fn handle_client_text(
                     camera_state::connection_subscribed(connection_id, camera_uuid);
                 if !camera_state::subscribe(connection_id, camera_uuid) {
                     warn!(%connection_id, %camera_uuid, "Rejecting subscribe; at camera cap");
+                    // close_notify already woken on Full; read loop exits via the notify arm.
                     let _ = queue_subscribe_rejected(
                         connection_id,
                         response_tx,
@@ -366,6 +368,14 @@ async fn handle_client_text(
                 camera_state::unsubscribe(connection_id, camera_uuid);
             }
             WsClientMessage::UiDismiss { camera_uuid, field } => {
+                if !camera_state::connection_subscribed(connection_id, camera_uuid) {
+                    debug!(
+                        %connection_id,
+                        %camera_uuid,
+                        "Ignoring ui_dismiss for unsubscribed camera"
+                    );
+                    return;
+                }
                 camera_ui::dismiss(camera_uuid, field);
             }
         }
@@ -619,7 +629,11 @@ async fn handle_request(request: WsRequest) -> WsResponse {
 
             match control_bridge::camera_control(camera_control).await {
                 Ok(value) => WsResponse::new(id, 200, value),
-                Err(error) => WsResponse::new(id, 500, Value::String(error)),
+                Err(error) => WsResponse::new(
+                    id,
+                    control_bridge::status_for_error(&error),
+                    Value::String(error),
+                ),
             }
         }
         ("POST", "/autopilot/control") => {
@@ -637,7 +651,11 @@ async fn handle_request(request: WsRequest) -> WsResponse {
 
             match control_bridge::autopilot_control(actuators_control).await {
                 Ok(value) => WsResponse::new(id, 200, value),
-                Err(error) => WsResponse::new(id, 500, Value::String(error)),
+                Err(error) => WsResponse::new(
+                    id,
+                    control_bridge::status_for_error(&error),
+                    Value::String(error),
+                ),
             }
         }
         _ => WsResponse::new(id, 404, Value::String("not found".to_string())),

--- a/backend/libs/radcam_manager/src/web/routes/v1/ws.rs
+++ b/backend/libs/radcam_manager/src/web/routes/v1/ws.rs
@@ -257,8 +257,15 @@ fn spawn_lag_recovery(
             let _lag_guard = lag_guard;
             for camera_uuid in camera_state::connection_cameras(connection_id) {
                 let Ok(permit) = snapshot_permits.clone().try_acquire_owned() else {
-                    debug!(%connection_id, %camera_uuid, "No permit for lag-recovery snapshot");
-                    // Slow watcher backfills when permits are exhausted.
+                    debug!(%connection_id, %camera_uuid, "No permit for lag-recovery snapshot; pushing actuators only");
+                    // Slow watcher does not backfill actuators_state; push manager cache.
+                    if let Some(event) =
+                        camera_state::actuators_state_event(camera_uuid).await
+                        && let Some(text) = state_event_text(&event)
+                        && !queue_text(connection_id, &response_tx, &close_notify, text)
+                    {
+                        return;
+                    }
                     continue;
                 };
                 let event = camera_state::snapshot(camera_uuid).await;
@@ -629,11 +636,7 @@ async fn handle_request(request: WsRequest) -> WsResponse {
 
             match control_bridge::camera_control(camera_control).await {
                 Ok(value) => WsResponse::new(id, 200, value),
-                Err(error) => WsResponse::new(
-                    id,
-                    control_bridge::status_for_error(&error),
-                    Value::String(error),
-                ),
+                Err(error) => WsResponse::new(id, error.status, Value::String(error.message)),
             }
         }
         ("POST", "/autopilot/control") => {
@@ -651,11 +654,7 @@ async fn handle_request(request: WsRequest) -> WsResponse {
 
             match control_bridge::autopilot_control(actuators_control).await {
                 Ok(value) => WsResponse::new(id, 200, value),
-                Err(error) => WsResponse::new(
-                    id,
-                    control_bridge::status_for_error(&error),
-                    Value::String(error),
-                ),
+                Err(error) => WsResponse::new(id, error.status, Value::String(error.message)),
             }
         }
         _ => WsResponse::new(id, 404, Value::String("not found".to_string())),


### PR DESCRIPTION
## Summary
Split from the websockets work: **Harden camera state concurrency and set_param paths**.

Commits in this slice:
- `backend: libs: autopilot: Fix freeze on focus/zoom correlation toggle`
- `backend: libs: Harden camera state concurrency and control errors`
- `backend: libs: Fix actuators lag resync and typed control errors`
- `backend: libs: Fix set_param hang, fresh SERVO cache, and snapshot UI races`

## Stack
- Part **13/24** of the websockets split (all PRs target `master`)
- Depends on https://github.com/bluerobotics/radcam-manager/pull/213 merging first.
- After the previous stack PR merges: rebase this branch onto `master` and `git push --force-with-lease`
- Intermediate slices may show **red CI** (incomplete stack / missing later fixes). That is expected.
- The batch is only done when tip **[#225](https://github.com/bluerobotics/radcam-manager/pull/225)** (`24/24`) is green after the full merge-rebase dance.

## Test plan
- [ ] Focus/zoom correlation toggle does not freeze the autopilot manager
- [ ] Concurrent camera controls return typed errors (e.g. unknown camera → 404) without wedging state
- [ ] Actuators lag recovery re-pushes state to subscribers after a missed SERVO window
