### PR TITLE
websockets 15/24: Fix subscribe, remount, generation, and venc races

### DIFF
--- a/frontend/src/components/BasicSettings.vue
+++ b/frontend/src/components/BasicSettings.vue
@@ -1041,7 +1041,12 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
   backendClient
     .request('POST', '/camera/control', payload)
     .then((data) => {
-      if (props.selectedCameraUuid !== cameraUuid) return
+      if (
+        props.selectedCameraUuid !== cameraUuid ||
+        generation !== actuatorsRequestGeneration.value
+      ) {
+        return
+      }
       baseParams.value = data as BaseParameterSetting
     })
     .catch((error) => {
@@ -1186,7 +1191,12 @@ const updateActuatorsConfig = (param: keyof ActuatorsParametersConfig, value: an
   backendClient
     .request('POST', '/autopilot/control', payload)
     .then((data) => {
-      if (props.selectedCameraUuid !== cameraUuid) return
+      if (
+        props.selectedCameraUuid !== cameraUuid ||
+        generation !== actuatorsRequestGeneration.value
+      ) {
+        return
+      }
       const newParams = (data as ActuatorsConfig)?.parameters
       if (newParams) {
         currentFocusAndZoomParams.value = { ...newParams }
@@ -1483,9 +1493,12 @@ const saveVideoDataAndRestart = async (): Promise<void> => {
   if (Object.keys(videoPartial).length > 0) {
     try {
       await updateVideoParameters(videoPartial)
-      if (props.selectedCameraUuid !== cameraUuid) return
+      // Always reboot the camera that accepted the venc change, even if the
+      // user switched selection afterward.
       doRestart(cameraUuid)
-      Object.assign(selectedVideoParameters.value, videoPartial)
+      if (props.selectedCameraUuid === cameraUuid) {
+        Object.assign(selectedVideoParameters.value, videoPartial)
+      }
     } catch {
       return
     }

--- a/frontend/src/components/BasicSettings.vue
+++ b/frontend/src/components/BasicSettings.vue
@@ -836,6 +836,7 @@ watch(
     correlationToggleInFlight.value = false
     isConfigured.value = false
     showAdvancedHardware.value = false
+    processingWhiteBalance.value = false
     const emptyParams: ActuatorsParametersConfig = {
       camera_id: null,
       focus_channel: null,
@@ -1025,6 +1026,7 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
   }
 
   const cameraUuid = props.selectedCameraUuid
+  const generation = actuatorsRequestGeneration.value
   baseParams.value = { ...baseParams.value, [param]: value }
   inFlightParamWrites.value++
 
@@ -1047,6 +1049,7 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
       console.log(message, error.message)
     })
     .finally(() => {
+      if (generation !== actuatorsRequestGeneration.value) return
       inFlightParamWrites.value = Math.max(0, inFlightParamWrites.value - 1)
     })
 }
@@ -1159,6 +1162,7 @@ const updateActuatorsConfig = (param: keyof ActuatorsParametersConfig, value: an
   }
 
   const cameraUuid = props.selectedCameraUuid
+  const generation = actuatorsRequestGeneration.value
   const previousCorrelation =
     param === 'enable_focus_and_zoom_correlation'
       ? currentFocusAndZoomParams.value.enable_focus_and_zoom_correlation
@@ -1193,7 +1197,8 @@ const updateActuatorsConfig = (param: keyof ActuatorsParametersConfig, value: an
     .catch((error) => {
       if (
         param === 'enable_focus_and_zoom_correlation' &&
-        props.selectedCameraUuid === cameraUuid
+        props.selectedCameraUuid === cameraUuid &&
+        generation === actuatorsRequestGeneration.value
       ) {
         currentFocusAndZoomParams.value = {
           ...currentFocusAndZoomParams.value,
@@ -1204,7 +1209,10 @@ const updateActuatorsConfig = (param: keyof ActuatorsParametersConfig, value: an
       console.log(message, error.message)
     })
     .finally(() => {
-      if (param === 'enable_focus_and_zoom_correlation') {
+      if (
+        param === 'enable_focus_and_zoom_correlation' &&
+        generation === actuatorsRequestGeneration.value
+      ) {
         correlationToggleInFlight.value = false
       }
     })
@@ -1293,13 +1301,15 @@ const getBaseParameters = () => {
     return
   }
 
+  const cameraUuid = props.selectedCameraUuid
   const payload = {
-    camera_uuid: props.selectedCameraUuid,
+    camera_uuid: cameraUuid,
     action: "getImageAdjustment",
   }
 
   backendClient.request('POST', '/camera/control', payload)
     .then(data => {
+      if (props.selectedCameraUuid !== cameraUuid) return
       baseParams.value = data as BaseParameterSetting
       console.log(data)
     })
@@ -1313,14 +1323,16 @@ const updateVideoParameters = async (
 ): Promise<void> => {
   if (!props.selectedCameraUuid || props.disabled) return
 
+  const cameraUuid = props.selectedCameraUuid
   const payload = {
-    camera_uuid: props.selectedCameraUuid,
+    camera_uuid: cameraUuid,
     action: 'setVencConf',
     json: partial as VideoParameterSettings,
   }
 
   try {
     const data = await backendClient.request('POST', '/camera/control', payload)
+    if (props.selectedCameraUuid !== cameraUuid) return
     const settings = data as VideoParameterSettings
     update_video_parameter_values(settings)
   } catch (error) {
@@ -1411,8 +1423,10 @@ const doWhiteBalance = async () => {
   if (processingWhiteBalance.value) return
   processingWhiteBalance.value = true
 
+  const cameraUuid = props.selectedCameraUuid
+  const generation = actuatorsRequestGeneration.value
   const payload: CameraControl = {
-    camera_uuid: props.selectedCameraUuid,
+    camera_uuid: cameraUuid,
     action: "setImageAdjustmentEx",
     json: {
       onceAWB: 1,
@@ -1423,18 +1437,22 @@ const doWhiteBalance = async () => {
     .catch(error => {
       console.error("Error sending onceAWB control:", error.message)
     }).finally(() => {
+      if (generation !== actuatorsRequestGeneration.value) return
       processingWhiteBalance.value = false
-      getBaseParameters()
+      if (props.selectedCameraUuid === cameraUuid) {
+        getBaseParameters()
+      }
     })
 }
 
-const doRestart = () => {
-  if (!props.selectedCameraUuid || props.disabled) {
+const doRestart = (cameraUuid?: string) => {
+  const uuid = cameraUuid ?? props.selectedCameraUuid
+  if (!uuid || props.disabled) {
     return
   }
 
   const payload = {
-    camera_uuid: props.selectedCameraUuid,
+    camera_uuid: uuid,
     action: "restart",
   }
 
@@ -1451,6 +1469,7 @@ const doRestart = () => {
 const saveVideoDataAndRestart = async (): Promise<void> => {
   if (!props.selectedCameraUuid || props.disabled) return
 
+  const cameraUuid = props.selectedCameraUuid
   const curr = selectedVideoParameters.value
   const newWidth = selectedVideoResolution.value?.width ?? null
   const newHeight = selectedVideoResolution.value?.height ?? null
@@ -1464,7 +1483,8 @@ const saveVideoDataAndRestart = async (): Promise<void> => {
   if (Object.keys(videoPartial).length > 0) {
     try {
       await updateVideoParameters(videoPartial)
-      doRestart()
+      if (props.selectedCameraUuid !== cameraUuid) return
+      doRestart(cameraUuid)
       Object.assign(selectedVideoParameters.value, videoPartial)
     } catch {
       return
@@ -1517,6 +1537,7 @@ const saveHardwareSetup = async (): Promise<void> => {
     return
   }
 
+  const cameraUuid = props.selectedCameraUuid
   let payloadParams: ActuatorsParametersConfig
   payloadParams = { ...defaultFocusAndZoomParams.value }
   if (showAdvancedHardware.value) {
@@ -1524,7 +1545,7 @@ const saveHardwareSetup = async (): Promise<void> => {
   }
 
   const payload: ActuatorsControl = {
-    camera_uuid: props.selectedCameraUuid,
+    camera_uuid: cameraUuid,
     action: "setActuatorsConfig",
     json: { parameters: payloadParams } as ActuatorsConfig
   }
@@ -1534,6 +1555,7 @@ const saveHardwareSetup = async (): Promise<void> => {
   backendClient
     .request('POST', '/autopilot/control', payload)
     .then((data) => {
+      if (props.selectedCameraUuid !== cameraUuid) return
       console.log("Got an answer from the setActuatorsConfig request", data)
 
       const newParams = (data as ActuatorsConfig)?.parameters
@@ -1551,14 +1573,16 @@ const saveHardwareSetup = async (): Promise<void> => {
 const resetToRecommendedDefaults = async (): Promise<void> => {
   if (!props.selectedCameraUuid || props.disabled) return
 
+  const cameraUuid = props.selectedCameraUuid
   const payload = {
-    camera_uuid: props.selectedCameraUuid,
+    camera_uuid: cameraUuid,
     action: 'resetActuatorsConfig',
   }
 
   backendClient
     .request('POST', '/autopilot/control', payload)
     .then((data) => {
+      if (props.selectedCameraUuid !== cameraUuid) return
       console.log("Got an answer from the setActuatorsConfig request", data)
 
       const newParams = (data as ActuatorsConfig)?.parameters

--- a/frontend/src/components/BasicSettings.vue
+++ b/frontend/src/components/BasicSettings.vue
@@ -765,7 +765,10 @@ const actuatorsSetQueued = ref<Record<ActuatorKey, number | null>>({
   zoom: null,
   tilt: null,
 })
-const isConfigured = ref<boolean>(true)
+/** Bumped on camera switch so in-flight actuator POSTs ignore stale `.finally` cleanup. */
+const actuatorsRequestGeneration = ref(0)
+const correlationToggleInFlight = ref(false)
+const isConfigured = ref<boolean>(false)
 const showWelcomeDialog = ref<boolean>(true)
 const showAdvancedHardware = ref(false)
 const intendedFocusAndZoomParams = ref<ActuatorsParametersConfig>({
@@ -828,10 +831,43 @@ watch(
   () => {
     hasUserEditedVideo.value = false
     hasUnsavedVideoChanges.value = false
-    intendedFocusAndZoomParams.value.camera_id = null
+    actuatorsRequestGeneration.value += 1
     inFlightParamWrites.value = 0
+    correlationToggleInFlight.value = false
+    isConfigured.value = false
+    showAdvancedHardware.value = false
+    const emptyParams: ActuatorsParametersConfig = {
+      camera_id: null,
+      focus_channel: null,
+      focus_channel_min: null,
+      focus_channel_trim: null,
+      focus_channel_max: null,
+      focus_margin_gain: null,
+      script_function: null,
+      script_channel: null,
+      script_channel_min: null,
+      script_channel_trim: null,
+      script_channel_max: null,
+      enable_focus_and_zoom_correlation: null,
+      zoom_channel: null,
+      zoom_channel_min: null,
+      zoom_channel_trim: null,
+      zoom_channel_max: null,
+      tilt_channel: null,
+      tilt_channel_min: null,
+      tilt_channel_trim: null,
+      tilt_channel_max: null,
+      tilt_channel_reversed: null,
+      tilt_mnt_type: null,
+      tilt_mnt_pitch_min: null,
+      tilt_mnt_pitch_max: null,
+    }
+    intendedFocusAndZoomParams.value = { ...emptyParams }
+    currentFocusAndZoomParams.value = { ...emptyParams }
+    defaultFocusAndZoomParams.value = { ...emptyParams }
     desiredActuatorsState.value = { focus: null, zoom: null, tilt: null }
     actuatorsSetQueued.value = { focus: null, zoom: null, tilt: null }
+    actuatorsSetInFlight.value = { focus: false, zoom: false, tilt: false }
   },
 )
 
@@ -988,11 +1024,12 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
     return
   }
 
+  const cameraUuid = props.selectedCameraUuid
   baseParams.value = { ...baseParams.value, [param]: value }
   inFlightParamWrites.value++
 
   const payload = {
-    camera_uuid: props.selectedCameraUuid,
+    camera_uuid: cameraUuid,
     action: 'setImageAdjustment',
     json: {
       [param]: value,
@@ -1002,6 +1039,7 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
   backendClient
     .request('POST', '/camera/control', payload)
     .then((data) => {
+      if (props.selectedCameraUuid !== cameraUuid) return
       baseParams.value = data as BaseParameterSetting
     })
     .catch((error) => {
@@ -1019,11 +1057,12 @@ const applyActuatorsConfig = (data: ActuatorsConfig) => {
     if (intendedFocusAndZoomParams.value.camera_id === null) {
       intendedFocusAndZoomParams.value = { ...newParams }
     }
-    currentFocusAndZoomParams.value = { ...newParams }
+    if (!correlationToggleInFlight.value) {
+      currentFocusAndZoomParams.value = { ...newParams }
+    }
   } else {
     console.warn("Received null 'parameters' from response:", data)
   }
-  isConfigured.value = true
 }
 
 const applyActuatorsDefaultConfig = (data: ActuatorsConfig) => {
@@ -1053,7 +1092,6 @@ const applyActuatorsState = (state: ActuatorsState) => {
       actuatorsState.value[key] = received
     }
   })
-  isConfigured.value = true
 }
 
 const applyCameraStateEvent = (body: unknown) => {
@@ -1120,8 +1158,23 @@ const updateActuatorsConfig = (param: keyof ActuatorsParametersConfig, value: an
     return
   }
 
+  const cameraUuid = props.selectedCameraUuid
+  const previousCorrelation =
+    param === 'enable_focus_and_zoom_correlation'
+      ? currentFocusAndZoomParams.value.enable_focus_and_zoom_correlation
+      : null
+
+  if (param === 'enable_focus_and_zoom_correlation') {
+    if (correlationToggleInFlight.value) return
+    correlationToggleInFlight.value = true
+    currentFocusAndZoomParams.value = {
+      ...currentFocusAndZoomParams.value,
+      enable_focus_and_zoom_correlation: value,
+    }
+  }
+
   const payload: ActuatorsControl = {
-    camera_uuid: props.selectedCameraUuid,
+    camera_uuid: cameraUuid,
     action: "setActuatorsConfig",
     json: { "parameters": { [param]: value } as ActuatorsParametersConfig} as ActuatorsConfig
   }
@@ -1129,6 +1182,7 @@ const updateActuatorsConfig = (param: keyof ActuatorsParametersConfig, value: an
   backendClient
     .request('POST', '/autopilot/control', payload)
     .then((data) => {
+      if (props.selectedCameraUuid !== cameraUuid) return
       const newParams = (data as ActuatorsConfig)?.parameters
       if (newParams) {
         currentFocusAndZoomParams.value = { ...newParams }
@@ -1137,8 +1191,22 @@ const updateActuatorsConfig = (param: keyof ActuatorsParametersConfig, value: an
       }
     })
     .catch((error) => {
+      if (
+        param === 'enable_focus_and_zoom_correlation' &&
+        props.selectedCameraUuid === cameraUuid
+      ) {
+        currentFocusAndZoomParams.value = {
+          ...currentFocusAndZoomParams.value,
+          enable_focus_and_zoom_correlation: previousCorrelation,
+        }
+      }
       const message = `Error sending ${String(param)} control with value '${value}'`
       console.log(message, error.message)
+    })
+    .finally(() => {
+      if (param === 'enable_focus_and_zoom_correlation') {
+        correlationToggleInFlight.value = false
+      }
     })
 }
 
@@ -1151,6 +1219,7 @@ const sendQueuedActuatorState = (param: ActuatorKey): void => {
   if (value === null) return
 
   const cameraUuid = props.selectedCameraUuid
+  const generation = actuatorsRequestGeneration.value
   actuatorsSetQueued.value[param] = null
   actuatorsSetInFlight.value[param] = true
 
@@ -1167,13 +1236,12 @@ const sendQueuedActuatorState = (param: ActuatorKey): void => {
       console.log(message, error.message)
     })
     .finally(() => {
-      actuatorsSetInFlight.value[param] = false
-
-      if (props.selectedCameraUuid !== cameraUuid) {
-        actuatorsSetQueued.value[param] = null
-        desiredActuatorsState.value[param] = null
+      // Camera switched while this request was in flight — leave the new camera alone.
+      if (generation !== actuatorsRequestGeneration.value) {
         return
       }
+
+      actuatorsSetInFlight.value[param] = false
 
       // If a newer value was queued while this request was in-flight, send it now.
       if (actuatorsSetQueued.value[param] !== null) {
@@ -1511,6 +1579,8 @@ watch(
   () => selectedVideoResolution.value,
   (newRes) => {
     if (!newRes) return
+    // Only sync the local bitrate picker; never POST from a resolution change
+    // that may have come from camera/state (that races SAVE AND RESTART).
     const key = `${newRes.width}x${newRes.height}`
     const allowed = resolutionsToBitrate[key]
     if (!allowed || allowed.length === 0) {
@@ -1518,8 +1588,7 @@ watch(
       return
     }
     if (!selectedVideoBitrate.value || !allowed.includes(selectedVideoBitrate.value)) {
-      selectedVideoBitrate.value = allowed[0]                                  
-      updateVideoParameters({ bitrate: allowed[0] })                          
+      selectedVideoBitrate.value = allowed[0]
     }
   }
 )

--- a/frontend/src/components/BasicSettings.vue
+++ b/frontend/src/components/BasicSettings.vue
@@ -1457,7 +1457,11 @@ const doWhiteBalance = async () => {
 
 const doRestart = (cameraUuid?: string) => {
   const uuid = cameraUuid ?? props.selectedCameraUuid
-  if (!uuid || props.disabled) {
+  if (!uuid) {
+    return
+  }
+  // Explicit captured UUID must still reboot even if the current selection is disabled.
+  if (cameraUuid == null && props.disabled) {
     return
   }
 
@@ -1565,10 +1569,17 @@ const saveHardwareSetup = async (): Promise<void> => {
 
   console.log('Saving hardware setup:', payload)
 
+  const generation = actuatorsRequestGeneration.value
+
   backendClient
     .request('POST', '/autopilot/control', payload)
     .then((data) => {
-      if (props.selectedCameraUuid !== cameraUuid) return
+      if (
+        props.selectedCameraUuid !== cameraUuid ||
+        generation !== actuatorsRequestGeneration.value
+      ) {
+        return
+      }
       console.log("Got an answer from the setActuatorsConfig request", data)
 
       const newParams = (data as ActuatorsConfig)?.parameters
@@ -1587,6 +1598,7 @@ const resetToRecommendedDefaults = async (): Promise<void> => {
   if (!props.selectedCameraUuid || props.disabled) return
 
   const cameraUuid = props.selectedCameraUuid
+  const generation = actuatorsRequestGeneration.value
   const payload = {
     camera_uuid: cameraUuid,
     action: 'resetActuatorsConfig',
@@ -1595,7 +1607,12 @@ const resetToRecommendedDefaults = async (): Promise<void> => {
   backendClient
     .request('POST', '/autopilot/control', payload)
     .then((data) => {
-      if (props.selectedCameraUuid !== cameraUuid) return
+      if (
+        props.selectedCameraUuid !== cameraUuid ||
+        generation !== actuatorsRequestGeneration.value
+      ) {
+        return
+      }
       console.log("Got an answer from the setActuatorsConfig request", data)
 
       const newParams = (data as ActuatorsConfig)?.parameters

--- a/frontend/src/components/BlueSlider.vue
+++ b/frontend/src/components/BlueSlider.vue
@@ -293,7 +293,8 @@ const clearCommitLock = (): void => {
 }
 
 const setCommitLock = (val: number): void => {
-  const lockMs = 2000
+  // Short lock: ignore echo of our own commit without freezing correlation-driven updates.
+  const lockMs = 400
   commitLockValue.value = val
   commitLockUntilMs.value = Date.now() + lockMs
   if (commitLockTimeout) clearTimeout(commitLockTimeout)

--- a/frontend/src/components/BlueSlider.vue
+++ b/frontend/src/components/BlueSlider.vue
@@ -449,10 +449,14 @@ watch(
     if (isEditingCurrentSliderValue.value || isInteracting.value) return
     if (
       commitLockValue.value !== null &&
-      Date.now() < commitLockUntilMs.value &&
-      !approxEqual(next, commitLockValue.value)
+      Date.now() < commitLockUntilMs.value
     ) {
-      return
+      if (approxEqual(next, commitLockValue.value)) {
+        // Echo of our own commit — already showing it.
+        return
+      }
+      // Foreign / correlation-driven update — take it.
+      clearCommitLock()
     }
     currentSliderValue.value = next
   },

--- a/frontend/src/components/BlueSlider.vue
+++ b/frontend/src/components/BlueSlider.vue
@@ -457,6 +457,7 @@ watch(
       }
       // Foreign / correlation-driven update — take it.
       clearCommitLock()
+      lastSentValue.value = next
     }
     currentSliderValue.value = next
   },

--- a/frontend/src/components/BlueSlider.vue
+++ b/frontend/src/components/BlueSlider.vue
@@ -457,9 +457,9 @@ watch(
       }
       // Foreign / correlation-driven update — take it.
       clearCommitLock()
-      lastSentValue.value = next
     }
     currentSliderValue.value = next
+    lastSentValue.value = next
   },
   { immediate: true }
 )

--- a/frontend/src/components/ImageTab.vue
+++ b/frontend/src/components/ImageTab.vue
@@ -730,7 +730,7 @@ import {
 import { enumToOptions } from '@/utils/enumUtils'
 import { backendClient } from '@/utils/backendClient'
 import { useCameraState } from '@/utils/useCameraState'
-import { ref, toRef } from 'vue'
+import { ref, toRef, watch } from 'vue'
 
 const props = defineProps<{
   selectedCameraUuid: string | null
@@ -848,7 +848,8 @@ const noiseReductionOptions = enumToOptions(AdvancedDisplayNoiseReductionValue)
 const _2dNrLevelOptions = enumToOptions(AdvancedDisplay2dNrLevelValue)
 const antiFlickerOptions = enumToOptions(AdvancedDisplayAntiflickerValue)
 
-const inFlightParamWrites = ref(0)
+const inFlightBaseWrites = ref(0)
+const inFlightAdvancedWrites = ref(0)
 
 const applyCameraStateEvent = (body: unknown) => {
   if (!props.selectedCameraUuid) return
@@ -856,17 +857,24 @@ const applyCameraStateEvent = (body: unknown) => {
 
   const data = body as Record<string, unknown>
   if (data.camera_uuid !== props.selectedCameraUuid) return
-  if (inFlightParamWrites.value > 0) return
 
-  if (data.base_parameters) {
+  if (data.base_parameters && inFlightBaseWrites.value === 0) {
     baseParams.value = data.base_parameters as BaseParameterSetting
   }
-  if (data.advanced_parameters) {
+  if (data.advanced_parameters && inFlightAdvancedWrites.value === 0) {
     advancedParams.value = data.advanced_parameters as AdvancedParameterSetting
   }
 }
 
 useCameraState(toRef(props, 'selectedCameraUuid'), applyCameraStateEvent)
+
+watch(
+  () => props.selectedCameraUuid,
+  () => {
+    inFlightBaseWrites.value = 0
+    inFlightAdvancedWrites.value = 0
+  },
+)
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
@@ -874,11 +882,12 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
     return
   }
 
+  const cameraUuid = props.selectedCameraUuid
   baseParams.value = { ...baseParams.value, [param]: value }
-  inFlightParamWrites.value++
+  inFlightBaseWrites.value++
 
   const payload = {
-    camera_uuid: props.selectedCameraUuid,
+    camera_uuid: cameraUuid,
     action: "setImageAdjustment",
     json: {
       [param]: value,
@@ -889,13 +898,14 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
 
   backendClient.request('POST', '/camera/control', payload)
     .then(data => {
+      if (props.selectedCameraUuid !== cameraUuid) return
       baseParams.value = data as BaseParameterSetting
     })
     .catch(error => {
       console.error(`Error sending ${String(param)} control with value '${value}':`, error.message)
     })
     .finally(() => {
-      inFlightParamWrites.value = Math.max(0, inFlightParamWrites.value - 1)
+      inFlightBaseWrites.value = Math.max(0, inFlightBaseWrites.value - 1)
     })
 }
 
@@ -904,13 +914,15 @@ const getBaseParameters = () => {
     return
   }
 
+  const cameraUuid = props.selectedCameraUuid
   const payload = {
-    camera_uuid: props.selectedCameraUuid,
+    camera_uuid: cameraUuid,
     action: "getImageAdjustment",
   }
 
   backendClient.request('POST', '/camera/control', payload)
     .then(data => {
+      if (props.selectedCameraUuid !== cameraUuid) return
       baseParams.value = data as BaseParameterSetting
       console.log(data)
     })
@@ -952,8 +964,9 @@ const doRestoreBase = async () => {
 
   processingBaseRestore.value = true
 
+  const cameraUuid = props.selectedCameraUuid
   const payload: CameraControl = {
-    camera_uuid: props.selectedCameraUuid,
+    camera_uuid: cameraUuid,
     action: "setImageAdjustment",
     json: {
       set_default: 1,
@@ -963,6 +976,7 @@ const doRestoreBase = async () => {
   backendClient
     .request('POST', '/camera/control', payload)
     .then(data => {
+      if (props.selectedCameraUuid !== cameraUuid) return
       baseParams.value = data as BaseParameterSetting
     })
     .catch(error => {
@@ -977,24 +991,26 @@ const doRestoreBase = async () => {
 const updateAdvancedParam = (param: keyof AdvancedParameterSetting, value: any) => {
   if (!props.selectedCameraUuid) return
 
+  const cameraUuid = props.selectedCameraUuid
   advancedParams.value = { ...advancedParams.value, [param]: value }
-  inFlightParamWrites.value++
+  inFlightAdvancedWrites.value++
 
   const payload: CameraControl = {
-    camera_uuid: props.selectedCameraUuid,
+    camera_uuid: cameraUuid,
     action: "setImageAdjustmentEx",
     json: { [param]: value } as AdvancedParameterSetting
   }
 
   backendClient.request('POST', '/camera/control', payload)
     .then(data => {
+      if (props.selectedCameraUuid !== cameraUuid) return
       advancedParams.value = data as AdvancedParameterSetting
     })
     .catch(error => {
       console.error(`Error updating ${param}:`, error.message)
     })
     .finally(() => {
-      inFlightParamWrites.value = Math.max(0, inFlightParamWrites.value - 1)
+      inFlightAdvancedWrites.value = Math.max(0, inFlightAdvancedWrites.value - 1)
     })
 }
 
@@ -1003,14 +1019,16 @@ const doRestoreAdvanced = async () => {
 
   processingAdvancedRestore.value = true
 
+  const cameraUuid = props.selectedCameraUuid
   const payload: CameraControl = {
-    camera_uuid: props.selectedCameraUuid,
+    camera_uuid: cameraUuid,
     action: "setImageAdjustmentEx",
     json: { set_default: 1 } as AdvancedParameterSetting
   }
 
   backendClient.request('POST', '/camera/control', payload)
     .then(data => {
+      if (props.selectedCameraUuid !== cameraUuid) return
       advancedParams.value = data as AdvancedParameterSetting
     })
     .catch(error => {

--- a/frontend/src/components/ImageTab.vue
+++ b/frontend/src/components/ImageTab.vue
@@ -875,6 +875,9 @@ watch(
     imageRequestGeneration.value += 1
     inFlightBaseWrites.value = 0
     inFlightAdvancedWrites.value = 0
+    processingWhiteBalance.value = false
+    processingBaseRestore.value = false
+    processingAdvancedRestore.value = false
   },
 )
 
@@ -901,7 +904,12 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
 
   backendClient.request('POST', '/camera/control', payload)
     .then(data => {
-      if (props.selectedCameraUuid !== cameraUuid) return
+      if (
+        props.selectedCameraUuid !== cameraUuid ||
+        generation !== imageRequestGeneration.value
+      ) {
+        return
+      }
       baseParams.value = data as BaseParameterSetting
     })
     .catch(error => {
@@ -958,9 +966,12 @@ const doWhiteBalance = async () => {
     .catch(error => {
       console.error("Error sending onceAWB control:", error.message)
     }).finally(() => {
-      if (generation !== imageRequestGeneration.value) return
+      // Always clear the spinner; only skip follow-up fetch on switch.
       processingWhiteBalance.value = false
-      if (props.selectedCameraUuid === cameraUuid) {
+      if (
+        generation === imageRequestGeneration.value &&
+        props.selectedCameraUuid === cameraUuid
+      ) {
         getBaseParameters()
       }
     })
@@ -1013,7 +1024,12 @@ const updateAdvancedParam = (param: keyof AdvancedParameterSetting, value: any) 
 
   backendClient.request('POST', '/camera/control', payload)
     .then(data => {
-      if (props.selectedCameraUuid !== cameraUuid) return
+      if (
+        props.selectedCameraUuid !== cameraUuid ||
+        generation !== imageRequestGeneration.value
+      ) {
+        return
+      }
       advancedParams.value = data as AdvancedParameterSetting
     })
     .catch(error => {

--- a/frontend/src/components/ImageTab.vue
+++ b/frontend/src/components/ImageTab.vue
@@ -850,6 +850,7 @@ const antiFlickerOptions = enumToOptions(AdvancedDisplayAntiflickerValue)
 
 const inFlightBaseWrites = ref(0)
 const inFlightAdvancedWrites = ref(0)
+const imageRequestGeneration = ref(0)
 
 const applyCameraStateEvent = (body: unknown) => {
   if (!props.selectedCameraUuid) return
@@ -871,6 +872,7 @@ useCameraState(toRef(props, 'selectedCameraUuid'), applyCameraStateEvent)
 watch(
   () => props.selectedCameraUuid,
   () => {
+    imageRequestGeneration.value += 1
     inFlightBaseWrites.value = 0
     inFlightAdvancedWrites.value = 0
   },
@@ -883,6 +885,7 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
   }
 
   const cameraUuid = props.selectedCameraUuid
+  const generation = imageRequestGeneration.value
   baseParams.value = { ...baseParams.value, [param]: value }
   inFlightBaseWrites.value++
 
@@ -905,6 +908,7 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
       console.error(`Error sending ${String(param)} control with value '${value}':`, error.message)
     })
     .finally(() => {
+      if (generation !== imageRequestGeneration.value) return
       inFlightBaseWrites.value = Math.max(0, inFlightBaseWrites.value - 1)
     })
 }
@@ -940,8 +944,10 @@ const doWhiteBalance = async () => {
   if (processingWhiteBalance.value) return
   processingWhiteBalance.value = true
 
+  const cameraUuid = props.selectedCameraUuid
+  const generation = imageRequestGeneration.value
   const payload: CameraControl = {
-    camera_uuid: props.selectedCameraUuid,
+    camera_uuid: cameraUuid,
     action: "setImageAdjustmentEx",
     json: {
       onceAWB: 1,
@@ -952,8 +958,11 @@ const doWhiteBalance = async () => {
     .catch(error => {
       console.error("Error sending onceAWB control:", error.message)
     }).finally(() => {
+      if (generation !== imageRequestGeneration.value) return
       processingWhiteBalance.value = false
-      getBaseParameters()
+      if (props.selectedCameraUuid === cameraUuid) {
+        getBaseParameters()
+      }
     })
 }
 
@@ -992,6 +1001,7 @@ const updateAdvancedParam = (param: keyof AdvancedParameterSetting, value: any) 
   if (!props.selectedCameraUuid) return
 
   const cameraUuid = props.selectedCameraUuid
+  const generation = imageRequestGeneration.value
   advancedParams.value = { ...advancedParams.value, [param]: value }
   inFlightAdvancedWrites.value++
 
@@ -1010,6 +1020,7 @@ const updateAdvancedParam = (param: keyof AdvancedParameterSetting, value: any) 
       console.error(`Error updating ${param}:`, error.message)
     })
     .finally(() => {
+      if (generation !== imageRequestGeneration.value) return
       inFlightAdvancedWrites.value = Math.max(0, inFlightAdvancedWrites.value - 1)
     })
 }

--- a/frontend/src/components/ImageTab.vue
+++ b/frontend/src/components/ImageTab.vue
@@ -927,6 +927,7 @@ const getBaseParameters = () => {
   }
 
   const cameraUuid = props.selectedCameraUuid
+  const generation = imageRequestGeneration.value
   const payload = {
     camera_uuid: cameraUuid,
     action: "getImageAdjustment",
@@ -934,7 +935,13 @@ const getBaseParameters = () => {
 
   backendClient.request('POST', '/camera/control', payload)
     .then(data => {
-      if (props.selectedCameraUuid !== cameraUuid) return
+      if (
+        props.selectedCameraUuid !== cameraUuid ||
+        generation !== imageRequestGeneration.value ||
+        inFlightBaseWrites.value > 0
+      ) {
+        return
+      }
       baseParams.value = data as BaseParameterSetting
       console.log(data)
     })
@@ -966,12 +973,9 @@ const doWhiteBalance = async () => {
     .catch(error => {
       console.error("Error sending onceAWB control:", error.message)
     }).finally(() => {
-      // Always clear the spinner; only skip follow-up fetch on switch.
+      if (generation !== imageRequestGeneration.value) return
       processingWhiteBalance.value = false
-      if (
-        generation === imageRequestGeneration.value &&
-        props.selectedCameraUuid === cameraUuid
-      ) {
+      if (props.selectedCameraUuid === cameraUuid) {
         getBaseParameters()
       }
     })
@@ -985,6 +989,7 @@ const doRestoreBase = async () => {
   processingBaseRestore.value = true
 
   const cameraUuid = props.selectedCameraUuid
+  const generation = imageRequestGeneration.value
   const payload: CameraControl = {
     camera_uuid: cameraUuid,
     action: "setImageAdjustment",
@@ -996,13 +1001,19 @@ const doRestoreBase = async () => {
   backendClient
     .request('POST', '/camera/control', payload)
     .then(data => {
-      if (props.selectedCameraUuid !== cameraUuid) return
+      if (
+        props.selectedCameraUuid !== cameraUuid ||
+        generation !== imageRequestGeneration.value
+      ) {
+        return
+      }
       baseParams.value = data as BaseParameterSetting
     })
     .catch(error => {
       console.error("Error sending base image restore control:", error.message)
     })
     .finally(() => {
+      if (generation !== imageRequestGeneration.value) return
       processingBaseRestore.value = false
     })
 }
@@ -1047,6 +1058,7 @@ const doRestoreAdvanced = async () => {
   processingAdvancedRestore.value = true
 
   const cameraUuid = props.selectedCameraUuid
+  const generation = imageRequestGeneration.value
   const payload: CameraControl = {
     camera_uuid: cameraUuid,
     action: "setImageAdjustmentEx",
@@ -1055,13 +1067,19 @@ const doRestoreAdvanced = async () => {
 
   backendClient.request('POST', '/camera/control', payload)
     .then(data => {
-      if (props.selectedCameraUuid !== cameraUuid) return
+      if (
+        props.selectedCameraUuid !== cameraUuid ||
+        generation !== imageRequestGeneration.value
+      ) {
+        return
+      }
       advancedParams.value = data as AdvancedParameterSetting
     })
     .catch(error => {
       console.error("Error restoring advanced parameters:", error.message)
     })
     .finally(() => {
+      if (generation !== imageRequestGeneration.value) return
       processingAdvancedRestore.value = false
     })
 }

--- a/frontend/src/components/Slider.vue
+++ b/frontend/src/components/Slider.vue
@@ -56,8 +56,11 @@ let sliderInterval: number | null = null
 let isSliding = false
 
 watch(() => props.current, (newVal) => {
-  current.value = newVal;
-});
+  current.value = newVal
+  if (!isSliding) {
+    lastSentValue.value = newVal
+  }
+})
 
 onBeforeUnmount(() => {
   if (sliderInterval) {

--- a/frontend/src/components/StreamsTab.vue
+++ b/frontend/src/components/StreamsTab.vue
@@ -148,18 +148,24 @@ const downloadedVideoParameters = ref<VideoParameterSettings>({})
 const selectedVideoResolution = ref<VideoResolutionValue | null>(null)
 const needs_restart = ref<boolean>(false)
 const hasUserEditedVideo = ref(false)
+const streamsRequestGeneration = ref(0)
 let suppressUserEditFlag = false
+let awaitingHydrate = false
 
 watch(
   () => props.selectedCameraUuid,
   async (newValue) => {
+    streamsRequestGeneration.value += 1
     hasUserEditedVideo.value = false
-    // Remount / switch: wait for first hydrate before latching dirty.
+    processingUpdate.value = false
+    // Hold dirty latch until the first successful hydrate for this camera.
     suppressUserEditFlag = true
-    queueMicrotask(() => {
+    awaitingHydrate = true
+    if (!newValue) {
       suppressUserEditFlag = false
-    })
-    if (!newValue) return
+      awaitingHydrate = false
+      return
+    }
     // MainStream is pushed on camera/state; other channels still need a fetch.
     const channel = selectedVideoParameters.value.channel ?? VideoChannelValue.MainStream
     if (channel !== VideoChannelValue.MainStream) {
@@ -216,7 +222,7 @@ watch(
 watch(
   [selectedVideoParameters, selectedVideoResolution],
   () => {
-    if (!suppressUserEditFlag) {
+    if (!suppressUserEditFlag && !awaitingHydrate) {
       hasUserEditedVideo.value = true
     }
   },
@@ -255,6 +261,7 @@ const updateVideoParameters = () => {
   }
 
   const cameraUuid = props.selectedCameraUuid
+  const generation = streamsRequestGeneration.value
   processingUpdate.value = true
 
   console.debug(selectedVideoParameters.value)
@@ -271,7 +278,12 @@ const updateVideoParameters = () => {
   backendClient
     .request('POST', '/camera/control', payload)
     .then((data) => {
-      if (props.selectedCameraUuid !== cameraUuid) return
+      if (
+        props.selectedCameraUuid !== cameraUuid ||
+        generation !== streamsRequestGeneration.value
+      ) {
+        return
+      }
       if (!shouldRestart) {
         const settings: VideoParameterSettings =
           data as VideoParameterSettings
@@ -285,11 +297,11 @@ const updateVideoParameters = () => {
       )
     )
     .finally(() => {
-      if (props.selectedCameraUuid !== cameraUuid) {
-        processingUpdate.value = false
+      if (generation !== streamsRequestGeneration.value) {
         return
       }
       if (shouldRestart) {
+        // Reboot the camera that accepted the venc change.
         doRestart(cameraUuid)
       } else {
         processingUpdate.value = false
@@ -303,6 +315,7 @@ const doRestart = (cameraUuid?: string) => {
     return
   }
 
+  const generation = streamsRequestGeneration.value
   console.log("Restarting...")
 
   processingUpdate.value = true
@@ -315,7 +328,12 @@ const doRestart = (cameraUuid?: string) => {
   backendClient
     .request('POST', '/camera/control', payload)
     .then((data) => {
-      if (props.selectedCameraUuid !== uuid) return
+      if (
+        props.selectedCameraUuid !== uuid ||
+        generation !== streamsRequestGeneration.value
+      ) {
+        return
+      }
       console.log("Got an answer from the restarting request", data)
       needs_restart.value = false
     })
@@ -326,9 +344,8 @@ const doRestart = (cameraUuid?: string) => {
       )
     )
     .finally(() => {
-      if (props.selectedCameraUuid === uuid) {
-        processingUpdate.value = false
-      }
+      if (generation !== streamsRequestGeneration.value) return
+      processingUpdate.value = false
     })
 }
 
@@ -338,6 +355,7 @@ const getVideoParameters = (update: boolean) => {
   }
 
   const cameraUuid = props.selectedCameraUuid
+  const generation = streamsRequestGeneration.value
   const video_parameter_settings = {
     channel: selectedVideoParameters.value.channel ?? VideoChannelValue.MainStream,
   }
@@ -351,7 +369,12 @@ const getVideoParameters = (update: boolean) => {
   backendClient
     .request('POST', '/camera/control', payload)
     .then((data) => {
-      if (props.selectedCameraUuid !== cameraUuid) return
+      if (
+        props.selectedCameraUuid !== cameraUuid ||
+        generation !== streamsRequestGeneration.value
+      ) {
+        return
+      }
       const settings: VideoParameterSettings =
         data as VideoParameterSettings
 
@@ -361,8 +384,16 @@ const getVideoParameters = (update: boolean) => {
     })
     .catch((error) => {
       console.error(`Error sending getVencConf request:`, error.message)
+      if (
+        props.selectedCameraUuid !== cameraUuid ||
+        generation !== streamsRequestGeneration.value
+      ) {
+        return
+      }
       // Don't latch the form dirty forever when the initial fetch fails.
       hasUserEditedVideo.value = false
+      suppressUserEditFlag = false
+      awaitingHydrate = false
     })
 }
 
@@ -378,6 +409,7 @@ const update_video_parameter_values = (settings: VideoParameterSettings) => {
     height: settings.pic_height!,
   } as VideoResolutionValue
   hasUserEditedVideo.value = false
+  awaitingHydrate = false
   queueMicrotask(() => {
     suppressUserEditFlag = false
   })

--- a/frontend/src/components/StreamsTab.vue
+++ b/frontend/src/components/StreamsTab.vue
@@ -154,6 +154,11 @@ watch(
   () => props.selectedCameraUuid,
   async (newValue) => {
     hasUserEditedVideo.value = false
+    // Remount / switch: wait for first hydrate before latching dirty.
+    suppressUserEditFlag = true
+    queueMicrotask(() => {
+      suppressUserEditFlag = false
+    })
     if (!newValue) return
     // MainStream is pushed on camera/state; other channels still need a fetch.
     const channel = selectedVideoParameters.value.channel ?? VideoChannelValue.MainStream
@@ -249,14 +254,16 @@ const updateVideoParameters = () => {
     return
   }
 
+  const cameraUuid = props.selectedCameraUuid
   processingUpdate.value = true
 
   console.debug(selectedVideoParameters.value)
 
   const video_parameter_settings = selectedVideoParameters.value
+  const shouldRestart = needs_restart.value
 
   const payload = {
-    camera_uuid: props.selectedCameraUuid,
+    camera_uuid: cameraUuid,
     action: "setVencConf",
     json: video_parameter_settings,
   }
@@ -264,7 +271,8 @@ const updateVideoParameters = () => {
   backendClient
     .request('POST', '/camera/control', payload)
     .then((data) => {
-      if (!needs_restart.value) {
+      if (props.selectedCameraUuid !== cameraUuid) return
+      if (!shouldRestart) {
         const settings: VideoParameterSettings =
           data as VideoParameterSettings
         update_video_parameter_values(settings)
@@ -277,16 +285,21 @@ const updateVideoParameters = () => {
       )
     )
     .finally(() => {
-      if (needs_restart.value) {
-        doRestart()
+      if (props.selectedCameraUuid !== cameraUuid) {
+        processingUpdate.value = false
+        return
+      }
+      if (shouldRestart) {
+        doRestart(cameraUuid)
       } else {
         processingUpdate.value = false
       }
     })
 }
 
-const doRestart = () => {
-  if (!props.selectedCameraUuid) {
+const doRestart = (cameraUuid?: string) => {
+  const uuid = cameraUuid ?? props.selectedCameraUuid
+  if (!uuid) {
     return
   }
 
@@ -295,13 +308,14 @@ const doRestart = () => {
   processingUpdate.value = true
 
   const payload = {
-    camera_uuid: props.selectedCameraUuid,
+    camera_uuid: uuid,
     action: "restart",
   }
 
   backendClient
     .request('POST', '/camera/control', payload)
     .then((data) => {
+      if (props.selectedCameraUuid !== uuid) return
       console.log("Got an answer from the restarting request", data)
       needs_restart.value = false
     })
@@ -312,7 +326,9 @@ const doRestart = () => {
       )
     )
     .finally(() => {
-      processingUpdate.value = false
+      if (props.selectedCameraUuid === uuid) {
+        processingUpdate.value = false
+      }
     })
 }
 

--- a/frontend/src/components/StreamsTab.vue
+++ b/frontend/src/components/StreamsTab.vue
@@ -154,7 +154,10 @@ watch(
   () => props.selectedCameraUuid,
   async (newValue) => {
     hasUserEditedVideo.value = false
-    if (newValue) {
+    if (!newValue) return
+    // MainStream is pushed on camera/state; other channels still need a fetch.
+    const channel = selectedVideoParameters.value.channel ?? VideoChannelValue.MainStream
+    if (channel !== VideoChannelValue.MainStream) {
       getVideoParameters(true)
     }
   },
@@ -318,12 +321,13 @@ const getVideoParameters = (update: boolean) => {
     return
   }
 
+  const cameraUuid = props.selectedCameraUuid
   const video_parameter_settings = {
     channel: selectedVideoParameters.value.channel ?? VideoChannelValue.MainStream,
   }
 
   const payload = {
-    camera_uuid: props.selectedCameraUuid,
+    camera_uuid: cameraUuid,
     action: "getVencConf",
     json: video_parameter_settings,
   }
@@ -331,6 +335,7 @@ const getVideoParameters = (update: boolean) => {
   backendClient
     .request('POST', '/camera/control', payload)
     .then((data) => {
+      if (props.selectedCameraUuid !== cameraUuid) return
       const settings: VideoParameterSettings =
         data as VideoParameterSettings
 

--- a/frontend/src/components/StreamsTab.vue
+++ b/frontend/src/components/StreamsTab.vue
@@ -146,7 +146,16 @@ const selectedVideoParameters = ref<VideoParameterSettings>({
 })
 const downloadedVideoParameters = ref<VideoParameterSettings>({})
 const selectedVideoResolution = ref<VideoResolutionValue | null>(null)
-const needs_restart = ref<boolean>(false)
+const needs_restart = computed(() => {
+  const selected = selectedVideoParameters.value
+  const downloaded = downloadedVideoParameters.value
+  return (
+    selected.encode_profile !== downloaded.encode_profile ||
+    selected.encode_type !== downloaded.encode_type ||
+    selected.pic_width !== downloaded.pic_width ||
+    selected.pic_height !== downloaded.pic_height
+  )
+})
 const hasUserEditedVideo = ref(false)
 const streamsRequestGeneration = ref(0)
 let suppressUserEditFlag = false
@@ -166,11 +175,8 @@ watch(
       awaitingHydrate = false
       return
     }
-    // MainStream is pushed on camera/state; other channels still need a fetch.
-    const channel = selectedVideoParameters.value.channel ?? VideoChannelValue.MainStream
-    if (channel !== VideoChannelValue.MainStream) {
-      getVideoParameters(true)
-    }
+    // Always fetch so awaitingHydrate cannot latch forever if state never arrives.
+    getVideoParameters(true)
   },
   { immediate: true },
 )
@@ -191,31 +197,6 @@ watch(
     if (newValue !== oldValue) {
       getVideoParameters(true)
     }
-  }
-)
-
-watch(
-  () => selectedVideoParameters.value.encode_profile,
-  async (newValue) => {
-    needs_restart.value = newValue !== downloadedVideoParameters.value.encode_profile
-  }
-)
-watch(
-  () => selectedVideoParameters.value.encode_type,
-  async (newValue) => {
-    needs_restart.value = newValue !== downloadedVideoParameters.value.encode_type
-  }
-)
-watch(
-  () => selectedVideoParameters.value.pic_width,
-  async (newValue) => {
-    needs_restart.value = newValue !== downloadedVideoParameters.value.pic_width
-  }
-)
-watch(
-  () => selectedVideoParameters.value.pic_height,
-  async (newValue) => {
-    needs_restart.value = newValue !== downloadedVideoParameters.value.pic_height
   }
 )
 
@@ -268,6 +249,7 @@ const updateVideoParameters = () => {
 
   const video_parameter_settings = selectedVideoParameters.value
   const shouldRestart = needs_restart.value
+  let handedOffRestart = false
 
   const payload = {
     camera_uuid: cameraUuid,
@@ -278,17 +260,22 @@ const updateVideoParameters = () => {
   backendClient
     .request('POST', '/camera/control', payload)
     .then((data) => {
+      if (shouldRestart) {
+        // Always reboot the camera that accepted the venc change, even if the
+        // user switched selection afterward.
+        handedOffRestart = true
+        doRestart(cameraUuid)
+        return
+      }
       if (
         props.selectedCameraUuid !== cameraUuid ||
         generation !== streamsRequestGeneration.value
       ) {
         return
       }
-      if (!shouldRestart) {
-        const settings: VideoParameterSettings =
-          data as VideoParameterSettings
-        update_video_parameter_values(settings)
-      }
+      const settings: VideoParameterSettings =
+        data as VideoParameterSettings
+      update_video_parameter_values(settings)
     })
     .catch((error) =>
       console.error(
@@ -300,10 +287,8 @@ const updateVideoParameters = () => {
       if (generation !== streamsRequestGeneration.value) {
         return
       }
-      if (shouldRestart) {
-        // Reboot the camera that accepted the venc change.
-        doRestart(cameraUuid)
-      } else {
+      // Restart path owns the spinner via doRestart after a successful POST.
+      if (!handedOffRestart) {
         processingUpdate.value = false
       }
     })
@@ -314,11 +299,18 @@ const doRestart = (cameraUuid?: string) => {
   if (!uuid) {
     return
   }
+  // Explicit captured UUID must still reboot even if the current selection is disabled.
+  if (cameraUuid == null && props.disabled) {
+    return
+  }
 
   const generation = streamsRequestGeneration.value
+  const manageSpinner = props.selectedCameraUuid === uuid
   console.log("Restarting...")
 
-  processingUpdate.value = true
+  if (manageSpinner) {
+    processingUpdate.value = true
+  }
 
   const payload = {
     camera_uuid: uuid,
@@ -335,7 +327,6 @@ const doRestart = (cameraUuid?: string) => {
         return
       }
       console.log("Got an answer from the restarting request", data)
-      needs_restart.value = false
     })
     .catch((error) =>
       console.error(
@@ -344,6 +335,7 @@ const doRestart = (cameraUuid?: string) => {
       )
     )
     .finally(() => {
+      if (!manageSpinner) return
       if (generation !== streamsRequestGeneration.value) return
       processingUpdate.value = false
     })

--- a/frontend/src/utils/backendClient.ts
+++ b/frontend/src/utils/backendClient.ts
@@ -210,7 +210,7 @@ class BackendClient {
         this.lastMessageAt = Date.now()
         this.setConnectionState('connected')
         this.startStaleCheck()
-        // Re-subscribe immediately; camera/list also re-queues as a second chance.
+        // Re-subscribe immediately on reconnect (do not wait for camera/list).
         if (this.subscribedCameraUuid) {
           this.queueSubscribe(this.subscribedCameraUuid)
         }
@@ -316,12 +316,6 @@ class BackendClient {
     }
 
     if (message.type === 'event') {
-      // Re-push subscribe when the list arrives so a reconnect during MCM boot
-      // does not leave the client permanently unsubscribed.
-      if (message.event === 'camera/list' && this.subscribedCameraUuid) {
-        this.queueSubscribe(this.subscribedCameraUuid)
-      }
-
       const handlers = this.eventHandlers.get(message.event)
       if (!handlers) return
       for (const handler of handlers) {
@@ -377,9 +371,10 @@ class BackendClient {
 
     for (let attempt = 0; attempt < REQUEST_MAX_ATTEMPTS; attempt++) {
       try {
-        // Let the reconnect timer own the next connect when one is already scheduled.
-        if (this.reconnectTimer !== null && this.ws?.readyState !== WebSocket.OPEN) {
-          throw new Error('WebSocket connection failed')
+        // Promote a scheduled reconnect into an immediate connect attempt.
+        if (this.reconnectTimer !== null) {
+          clearTimeout(this.reconnectTimer)
+          this.reconnectTimer = null
         }
         await this.connect()
         const result = await this.sendRequest<T>(method, path, body)
@@ -432,6 +427,13 @@ class BackendClient {
     // Always send subscribe so the backend re-pushes UI + snapshot for this
     // consumer (refcount > 0 alone used to skip the frame and leave remounts blank).
     this.queueSubscribe(cameraUuid)
+  }
+
+  /** Re-push subscribe for the active camera without changing refcounts (tab remount). */
+  refreshCameraSubscription(): void {
+    if (this.subscribedCameraUuid) {
+      this.queueSubscribe(this.subscribedCameraUuid)
+    }
   }
 
   /** Collapse same-uuid subscribes issued in the same tick into one wire frame. */
@@ -494,9 +496,11 @@ class BackendClient {
       : { type: 'unsubscribe', camera_uuid: cameraUuid }
     const payload = JSON.stringify(message)
     const send = (): void => {
-      if (this.ws?.readyState === WebSocket.OPEN) {
-        this.ws.send(payload)
-      }
+      if (this.ws?.readyState !== WebSocket.OPEN) return
+      // Drop stale deferred sends that no longer match the active subscription.
+      if (type === 'subscribe' && this.subscribedCameraUuid !== cameraUuid) return
+      if (type === 'unsubscribe' && this.subscribedCameraUuid === cameraUuid) return
+      this.ws.send(payload)
     }
 
     if (this.ws?.readyState === WebSocket.OPEN) {

--- a/frontend/src/utils/backendClient.ts
+++ b/frontend/src/utils/backendClient.ts
@@ -210,7 +210,10 @@ class BackendClient {
         this.lastMessageAt = Date.now()
         this.setConnectionState('connected')
         this.startStaleCheck()
-        // camera/list is the first server frame and re-subscribes; skip a duplicate here.
+        // Re-subscribe immediately; camera/list also re-queues as a second chance.
+        if (this.subscribedCameraUuid) {
+          this.queueSubscribe(this.subscribedCameraUuid)
+        }
         resolve()
       }
 
@@ -293,7 +296,8 @@ class BackendClient {
     let message: WsResponse | WsEvent
     try {
       message = JSON.parse(raw) as WsResponse | WsEvent
-    } catch {
+    } catch (error) {
+      console.warn('Ignoring invalid WebSocket JSON', error)
       return
     }
 
@@ -419,6 +423,7 @@ class BackendClient {
 
     if (this.subscribedCameraUuid && this.subscribedCameraUuid !== cameraUuid) {
       const previous = this.subscribedCameraUuid
+      // Single active wire UUID: drop previous counts and unsubscribe once.
       this.cameraSubscribeCounts.delete(previous)
       this.sendCameraSubscription('unsubscribe', previous)
     }
@@ -438,7 +443,8 @@ class BackendClient {
       this.subscribeQueued = false
       const pending = this.pendingSubscribe
       this.pendingSubscribe = null
-      if (pending) {
+      // Skip if unsubscribe cleared the active uuid in the same tick.
+      if (pending && pending === this.subscribedCameraUuid) {
         this.sendCameraSubscription('subscribe', pending)
       }
     })
@@ -476,7 +482,10 @@ class BackendClient {
       return
     }
 
-    this.connect().then(send).catch(() => {})
+    this.connect().then(send).catch((error) => {
+      // Local dismiss still cleared the overlay; wire retry is best-effort.
+      console.warn('Failed to send ui_dismiss', error)
+    })
   }
 
   private sendCameraSubscription(type: 'subscribe' | 'unsubscribe', cameraUuid: string): void {
@@ -495,8 +504,8 @@ class BackendClient {
       return
     }
 
-    this.connect().then(send).catch(() => {
-      // reconnect loop will resubscribe on open
+    this.connect().then(send).catch((error) => {
+      console.warn(`Failed to send camera ${type}`, error)
     })
   }
 }

--- a/frontend/src/utils/backendClient.ts
+++ b/frontend/src/utils/backendClient.ts
@@ -316,6 +316,18 @@ class BackendClient {
     }
 
     if (message.type === 'event') {
+      // Re-subscribe after MCM list arrives if an earlier subscribe was rejected
+      // while cameras were still coming online.
+      if (message.event === 'camera/list' && this.subscribedCameraUuid) {
+        this.queueSubscribe(this.subscribedCameraUuid)
+      }
+      if (message.event === 'camera/subscribe_rejected' && this.subscribedCameraUuid) {
+        const body = message.body as { camera_uuid?: string } | null
+        if (!body?.camera_uuid || body.camera_uuid === this.subscribedCameraUuid) {
+          this.queueSubscribe(this.subscribedCameraUuid)
+        }
+      }
+
       const handlers = this.eventHandlers.get(message.event)
       if (!handlers) return
       for (const handler of handlers) {

--- a/frontend/src/utils/backendClient.ts
+++ b/frontend/src/utils/backendClient.ts
@@ -98,6 +98,10 @@ class BackendClient {
   private cameraSubscribeCounts = new Map<string, number>()
   private pendingSubscribe: string | null = null
   private subscribeQueued = false
+  /** True once camera/state arrives for the active subscribe target. */
+  private hasCameraState = false
+  /** Re-subscribe on next camera/list only after unknown_camera rejection. */
+  private subscribeNeedsRetry = false
 
   private wsUrl(): string {
     const url = new URL('v1/ws', window.location.href)
@@ -316,15 +320,29 @@ class BackendClient {
     }
 
     if (message.type === 'event') {
-      // Re-subscribe after MCM list arrives if an earlier subscribe was rejected
-      // while cameras were still coming online.
+      // Re-subscribe after MCM list arrives only when we still need state
+      // (boot race) or the last reject was unknown_camera — not on every list churn.
       if (message.event === 'camera/list' && this.subscribedCameraUuid) {
-        this.queueSubscribe(this.subscribedCameraUuid)
+        if (!this.hasCameraState || this.subscribeNeedsRetry) {
+          this.queueSubscribe(this.subscribedCameraUuid)
+        }
       }
       if (message.event === 'camera/subscribe_rejected' && this.subscribedCameraUuid) {
-        const body = message.body as { camera_uuid?: string } | null
+        const body = message.body as { camera_uuid?: string; reason?: string } | null
         if (!body?.camera_uuid || body.camera_uuid === this.subscribedCameraUuid) {
-          this.queueSubscribe(this.subscribedCameraUuid)
+          if (body?.reason === 'unknown_camera') {
+            this.subscribeNeedsRetry = true
+            this.queueSubscribe(this.subscribedCameraUuid)
+          } else {
+            console.warn('Camera subscribe rejected:', body?.reason ?? 'unknown')
+          }
+        }
+      }
+      if (message.event === 'camera/state' && this.subscribedCameraUuid) {
+        const body = message.body as { camera_uuid?: string } | null
+        if (body?.camera_uuid === this.subscribedCameraUuid) {
+          this.hasCameraState = true
+          this.subscribeNeedsRetry = false
         }
       }
 
@@ -436,6 +454,8 @@ class BackendClient {
     }
 
     this.subscribedCameraUuid = cameraUuid
+    this.hasCameraState = false
+    this.subscribeNeedsRetry = false
     // Always send subscribe so the backend re-pushes UI + snapshot for this
     // consumer (refcount > 0 alone used to skip the frame and leave remounts blank).
     this.queueSubscribe(cameraUuid)

--- a/frontend/src/utils/useCameraState.ts
+++ b/frontend/src/utils/useCameraState.ts
@@ -1,34 +1,20 @@
-import { onMounted, onUnmounted, watch, type Ref } from 'vue'
+import { onUnmounted, type Ref } from 'vue'
 
 import { backendClient } from './backendClient'
 
+/**
+ * Bind a handler to `camera/state` for the selected camera.
+ *
+ * Wire subscribe/unsubscribe is owned by HomeView so tabs do not fight over
+ * refcounts. `selectedCameraUuid` is part of the API for callers that close over it.
+ */
 export function useCameraState(
-  selectedCameraUuid: Ref<string | null>,
+  _selectedCameraUuid: Ref<string | null>,
   handler: (body: unknown) => void,
 ) {
   const unsubscribe = backendClient.onEvent('camera/state', handler)
 
-  const subscribe = () => {
-    if (selectedCameraUuid.value) {
-      backendClient.subscribeCamera(selectedCameraUuid.value)
-    }
-  }
-
-  onMounted(subscribe)
-
   onUnmounted(() => {
     unsubscribe()
-    if (selectedCameraUuid.value) {
-      backendClient.unsubscribeCamera(selectedCameraUuid.value)
-    }
-  })
-
-  watch(selectedCameraUuid, (uuid, previousUuid) => {
-    if (previousUuid) {
-      backendClient.unsubscribeCamera(previousUuid)
-    }
-    if (uuid) {
-      subscribe()
-    }
   })
 }

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -458,7 +458,7 @@ const runAutopilotControl = (action: string, errorMessage: string): void => {
       console.log(data)
     })
     .catch((error) => {
-      console.error(`${errorMessage}: ${formatRequestError(error)}`)
+      warningToastMessage.value = `${errorMessage}: ${formatRequestError(error)}`
     })
 }
 
@@ -474,7 +474,7 @@ const runCameraControl = (action: string, errorMessage: string): void => {
       console.log(data)
     })
     .catch((error) => {
-      console.error(`${errorMessage}: ${formatRequestError(error)}`)
+      warningToastMessage.value = `${errorMessage}: ${formatRequestError(error)}`
     })
 }
 
@@ -494,8 +494,11 @@ const unsubscribeConnectionState = backendClient.onConnectionState((state, previ
   if (state === 'disconnected' && previousState !== 'disconnected') {
     disconnectedSince.value = new Date()
     connectionStats.value = null
+    uiByCamera.clear()
     uiLoading.value = false
     uiRebooting.value = false
+    errorDialogMessage.value = null
+    warningToastMessage.value = null
   }
   if (state === 'connected') {
     disconnectedSince.value = null

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -357,6 +357,13 @@ watch(selectedCameraUUID, (uuid, previousUuid) => {
   }
 })
 
+// Remounted Basic/Advanced tabs start empty; re-subscribe so the backend re-pushes cache.
+watch([configMode, tab], () => {
+  if (selectedCameraUUID.value) {
+    backendClient.refreshCameraSubscription()
+  }
+})
+
 const dismissErrorDialog = () => {
   if (selectedCameraUUID.value) {
     backendClient.dismissUi(selectedCameraUUID.value, 'error_dialog')

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -348,7 +348,13 @@ watch(selectedCameraUUID, (uuid, previousUuid) => {
 
   const ui = uiByCamera.get(uuid)
   if (ui) {
-    applyCameraUi(ui)
+    // Don't resurrect stale loading/rebooting overlays after unsubscribe.
+    applyCameraUi({
+      ...ui,
+      loading: false,
+      loading_message: null,
+      rebooting: false,
+    })
   } else {
     uiLoading.value = false
     uiRebooting.value = false
@@ -454,33 +460,39 @@ const rebootCamera = (): void => {
 }
 
 const runAutopilotControl = (action: string, errorMessage: string): void => {
-  if (!selectedCameraUUID.value || uiLoading.value || uiRebooting.value) return
+  const cameraUuid = selectedCameraUUID.value
+  if (!cameraUuid || uiLoading.value || uiRebooting.value) return
 
   backendClient
     .request('POST', '/autopilot/control', {
-      camera_uuid: selectedCameraUUID.value,
+      camera_uuid: cameraUuid,
       action,
     })
     .then((data) => {
+      if (selectedCameraUUID.value !== cameraUuid) return
       console.log(data)
     })
     .catch((error) => {
+      if (selectedCameraUUID.value !== cameraUuid) return
       warningToastMessage.value = `${errorMessage}: ${formatRequestError(error)}`
     })
 }
 
 const runCameraControl = (action: string, errorMessage: string): void => {
-  if (!selectedCameraUUID.value || uiLoading.value || uiRebooting.value) return
+  const cameraUuid = selectedCameraUUID.value
+  if (!cameraUuid || uiLoading.value || uiRebooting.value) return
 
   backendClient
     .request('POST', '/camera/control', {
-      camera_uuid: selectedCameraUUID.value,
+      camera_uuid: cameraUuid,
       action,
     })
     .then((data) => {
+      if (selectedCameraUUID.value !== cameraUuid) return
       console.log(data)
     })
     .catch((error) => {
+      if (selectedCameraUUID.value !== cameraUuid) return
       warningToastMessage.value = `${errorMessage}: ${formatRequestError(error)}`
     })
 }

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -352,7 +352,7 @@ watch(selectedCameraUUID, (uuid, previousUuid) => {
     applyCameraUi({
       ...ui,
       loading: false,
-      loading_message: null,
+      loading_message: undefined,
       rebooting: false,
     })
   } else {


### PR DESCRIPTION
## Summary
Split from the websockets work: **Fix subscribe, remount, generation, and venc races**.

Commits in this slice:
- `frontend: Fix camera-switch races and WebSocket subscribe ownership`
- `frontend: Fix remount refresh, restart UUID, and reconnect races`
- `frontend: Fix generation guards, WB stuck state, and subscribe retry`
- `frontend: Fix venc restart races, subscribe retry, and generation guards`
- `frontend: views: Fix CameraUiState loading_message type`

## Stack
- Part **15/24** of the websockets split (all PRs target `master`)
- Depends on https://github.com/bluerobotics/radcam-manager/pull/215 merging first.
- After the previous stack PR merges: rebase this branch onto `master` and `git push --force-with-lease`
- Intermediate slices may show **red CI** (incomplete stack / missing later fixes). That is expected.
- The batch is only done when tip **[#225](https://github.com/bluerobotics/radcam-manager/pull/225)** (`24/24`) is green after the full merge-rebase dance.

## Test plan
- [ ] Switching cameras unsubscribes the previous UUID before subscribing the next
- [ ] Remounting Basic/Advanced tabs refreshes subscription and repaints state
- [ ] Generation guards ignore late responses after camera switch / reconnect
- [ ] Venc restart uses the captured camera UUID even if selection changes mid-flight
