### PR TITLE
websockets 16/24: Harden dirty latch, Escape, focus, and rollback hydrate

### DIFF
--- a/frontend/src/components/BasicSettings.vue
+++ b/frontend/src/components/BasicSettings.vue
@@ -743,7 +743,15 @@ const actuatorsState = ref<ActuatorsState>({
 })
 type ActuatorKey = keyof ActuatorsState
 
-const approxEqual = (a: number, b: number): boolean => Math.abs(a - b) <= 0.5
+/** Match SERVO feedback within half a UI step (focus 0.1, zoom/tilt 1). */
+const actuatorMatchEpsilon: Record<ActuatorKey, number> = {
+  focus: 0.05,
+  zoom: 0.5,
+  tilt: 0.5,
+}
+
+const approxEqual = (a: number, b: number, key: ActuatorKey = 'zoom'): boolean =>
+  Math.abs(a - b) <= actuatorMatchEpsilon[key]
 
 // Tracks the last user-requested value per actuator. While a key is pending, we do not let
 // pushed state updates overwrite the UI with intermediate/stale values.
@@ -767,6 +775,8 @@ const actuatorsSetQueued = ref<Record<ActuatorKey, number | null>>({
 })
 /** Bumped on camera switch so in-flight actuator POSTs ignore stale `.finally` cleanup. */
 const actuatorsRequestGeneration = ref(0)
+/** Monotonic seq so only the newest image-param write may apply its response body. */
+let baseParamWriteSeq = 0
 const correlationToggleInFlight = ref(false)
 const isConfigured = ref<boolean>(false)
 const showWelcomeDialog = ref<boolean>(true)
@@ -832,6 +842,7 @@ watch(
     hasUserEditedVideo.value = false
     hasUnsavedVideoChanges.value = false
     actuatorsRequestGeneration.value += 1
+    baseParamWriteSeq += 1
     inFlightParamWrites.value = 0
     correlationToggleInFlight.value = false
     isConfigured.value = false
@@ -1027,6 +1038,8 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
 
   const cameraUuid = props.selectedCameraUuid
   const generation = actuatorsRequestGeneration.value
+  const writeSeq = ++baseParamWriteSeq
+  const previous = baseParams.value[param]
   baseParams.value = { ...baseParams.value, [param]: value }
   inFlightParamWrites.value++
 
@@ -1043,18 +1056,24 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
     .then((data) => {
       if (
         props.selectedCameraUuid !== cameraUuid ||
-        generation !== actuatorsRequestGeneration.value
+        generation !== actuatorsRequestGeneration.value ||
+        writeSeq !== baseParamWriteSeq
       ) {
         return
       }
-      // Only apply when this is the last in-flight write (avoid older responses clobbering).
-      if (inFlightParamWrites.value === 1) {
-        baseParams.value = data as BaseParameterSetting
-      }
+      baseParams.value = data as BaseParameterSetting
     })
     .catch((error) => {
       const message = `Error sending ${String(param)} control with value '${value}'`
       console.log(message, error.message)
+      if (
+        props.selectedCameraUuid !== cameraUuid ||
+        generation !== actuatorsRequestGeneration.value ||
+        writeSeq !== baseParamWriteSeq
+      ) {
+        return
+      }
+      baseParams.value = { ...baseParams.value, [param]: previous }
     })
     .finally(() => {
       if (generation !== actuatorsRequestGeneration.value) return
@@ -1092,7 +1111,7 @@ const applyActuatorsState = (state: ActuatorsState) => {
     const received = state[key]
 
     if (desired !== null) {
-      if (received !== null && received !== undefined && approxEqual(received, desired)) {
+      if (received !== null && received !== undefined && approxEqual(received, desired, key)) {
         desiredActuatorsState.value[key] = null
         actuatorsState.value[key] = received
       }
@@ -1256,6 +1275,11 @@ const sendQueuedActuatorState = (param: ActuatorKey, allowWhileDisabled = false)
     .catch((error) => {
       const message = `Error updating ${param}`
       console.log(message, error.message)
+      if (generation !== actuatorsRequestGeneration.value) return
+      // Failed command will never match SERVO — drop the latch for this value.
+      if (desiredActuatorsState.value[param] === value) {
+        desiredActuatorsState.value[param] = null
+      }
     })
     .finally(() => {
       // Camera switched while this request was in flight — leave the new camera alone.
@@ -1270,8 +1294,6 @@ const sendQueuedActuatorState = (param: ActuatorKey, allowWhileDisabled = false)
       if (actuatorsSetQueued.value[param] !== null) {
         sendQueuedActuatorState(param, true)
       }
-      // Leave desiredActuatorsState latched until SERVO feedback matches
-      // (see applyActuatorsState).
     })
 }
 
@@ -1286,7 +1308,7 @@ const updateActuatorsState = (param: keyof ActuatorsState, value: number) => {
 
   // Coalesce requests per actuator to prevent backlog.
   const existingQueued = actuatorsSetQueued.value[key]
-  if (existingQueued === null || !approxEqual(existingQueued, value)) {
+  if (existingQueued === null || !approxEqual(existingQueued, value, key)) {
     actuatorsSetQueued.value[key] = value
   }
   sendQueuedActuatorState(key)

--- a/frontend/src/components/BasicSettings.vue
+++ b/frontend/src/components/BasicSettings.vue
@@ -760,6 +760,39 @@ const desiredActuatorsState = ref<Record<ActuatorKey, number | null>>({
   zoom: null,
   tilt: null,
 })
+/** Drop desired latch if SERVO never enters epsilon (stuck / unreachable). */
+const DESIRED_LATCH_TIMEOUT_MS = 5_000
+const desiredLatchTimers: Partial<Record<ActuatorKey, number>> = {}
+/** Value to restore on failed POST when no newer command is pending. */
+const actuatorsSetRollback = ref<Record<ActuatorKey, number | null>>({
+  focus: null,
+  zoom: null,
+  tilt: null,
+})
+
+const clearDesiredLatch = (key: ActuatorKey): void => {
+  desiredActuatorsState.value[key] = null
+  const timer = desiredLatchTimers[key]
+  if (timer != null) {
+    clearTimeout(timer)
+    delete desiredLatchTimers[key]
+  }
+}
+
+const armDesiredLatch = (key: ActuatorKey, value: number): void => {
+  desiredActuatorsState.value[key] = value
+  const timer = desiredLatchTimers[key]
+  if (timer != null) clearTimeout(timer)
+  desiredLatchTimers[key] = window.setTimeout(() => {
+    delete desiredLatchTimers[key]
+    if (
+      desiredActuatorsState.value[key] !== null &&
+      approxEqual(desiredActuatorsState.value[key]!, value, key)
+    ) {
+      desiredActuatorsState.value[key] = null
+    }
+  }, DESIRED_LATCH_TIMEOUT_MS)
+}
 
 // Coalesce actuator set requests so only one request per actuator can be in-flight, always
 // sending the most recent value (prevents request pile-up).
@@ -777,6 +810,8 @@ const actuatorsSetQueued = ref<Record<ActuatorKey, number | null>>({
 const actuatorsRequestGeneration = ref(0)
 /** Monotonic seq so only the newest image-param write may apply its response body. */
 let baseParamWriteSeq = 0
+/** Fields with an optimistic write that must not be clobbered by WS/GET. */
+const dirtyBaseParamFields = new Set<keyof BaseParameterSetting>()
 const correlationToggleInFlight = ref(false)
 const isConfigured = ref<boolean>(false)
 const showWelcomeDialog = ref<boolean>(true)
@@ -877,9 +912,11 @@ watch(
     intendedFocusAndZoomParams.value = { ...emptyParams }
     currentFocusAndZoomParams.value = { ...emptyParams }
     defaultFocusAndZoomParams.value = { ...emptyParams }
-    desiredActuatorsState.value = { focus: null, zoom: null, tilt: null }
+    ;(['focus', 'zoom', 'tilt'] as const).forEach(clearDesiredLatch)
+    actuatorsSetRollback.value = { focus: null, zoom: null, tilt: null }
     actuatorsSetQueued.value = { focus: null, zoom: null, tilt: null }
     actuatorsSetInFlight.value = { focus: false, zoom: false, tilt: false }
+    dirtyBaseParamFields.clear()
   },
 )
 
@@ -1041,6 +1078,7 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
   const writeSeq = ++baseParamWriteSeq
   const previous = baseParams.value[param]
   baseParams.value = { ...baseParams.value, [param]: value }
+  dirtyBaseParamFields.add(param)
   inFlightParamWrites.value++
 
   const payload = {
@@ -1062,18 +1100,21 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
         return
       }
       baseParams.value = data as BaseParameterSetting
+      dirtyBaseParamFields.clear()
     })
     .catch((error) => {
       const message = `Error sending ${String(param)} control with value '${value}'`
       console.log(message, error.message)
       if (
         props.selectedCameraUuid !== cameraUuid ||
-        generation !== actuatorsRequestGeneration.value ||
-        writeSeq !== baseParamWriteSeq
+        generation !== actuatorsRequestGeneration.value
       ) {
         return
       }
-      baseParams.value = { ...baseParams.value, [param]: previous }
+      if (baseParams.value[param] === value) {
+        baseParams.value = { ...baseParams.value, [param]: previous }
+      }
+      dirtyBaseParamFields.delete(param)
     })
     .finally(() => {
       if (generation !== actuatorsRequestGeneration.value) return
@@ -1112,7 +1153,7 @@ const applyActuatorsState = (state: ActuatorsState) => {
 
     if (desired !== null) {
       if (received !== null && received !== undefined && approxEqual(received, desired, key)) {
-        desiredActuatorsState.value[key] = null
+        clearDesiredLatch(key)
         actuatorsState.value[key] = received
       }
       return
@@ -1143,12 +1184,20 @@ const applyCameraStateEvent = (body: unknown) => {
   if (data.actuators_state) {
     applyActuatorsState(data.actuators_state as ActuatorsState)
   }
-  if (data.video_parameters) {
+  if (data.video_parameters && !hasUserEditedVideo.value) {
     update_video_parameter_values(data.video_parameters as VideoParameterSettings)
   }
   if (data.base_parameters) {
-    if (inFlightParamWrites.value === 0) {
-      baseParams.value = data.base_parameters as BaseParameterSetting
+    const incoming = data.base_parameters as BaseParameterSetting
+    if (dirtyBaseParamFields.size === 0) {
+      baseParams.value = incoming
+    } else {
+      baseParams.value = {
+        ...incoming,
+        ...Object.fromEntries(
+          [...dirtyBaseParamFields].map((key) => [key, baseParams.value[key]]),
+        ),
+      } as BaseParameterSetting
     }
   }
 }
@@ -1277,8 +1326,21 @@ const sendQueuedActuatorState = (param: ActuatorKey, allowWhileDisabled = false)
       console.log(message, error.message)
       if (generation !== actuatorsRequestGeneration.value) return
       // Failed command will never match SERVO — drop the latch for this value.
-      if (desiredActuatorsState.value[param] === value) {
-        desiredActuatorsState.value[param] = null
+      if (
+        desiredActuatorsState.value[param] !== null &&
+        approxEqual(desiredActuatorsState.value[param]!, value, param)
+      ) {
+        clearDesiredLatch(param)
+      }
+      // Roll back optimistic UI if nothing newer is queued/desired.
+      if (
+        actuatorsSetQueued.value[param] === null &&
+        desiredActuatorsState.value[param] === null &&
+        actuatorsState.value[param] !== null &&
+        approxEqual(actuatorsState.value[param]!, value, param) &&
+        actuatorsSetRollback.value[param] !== null
+      ) {
+        actuatorsState.value[param] = actuatorsSetRollback.value[param]
       }
     })
     .finally(() => {
@@ -1293,6 +1355,8 @@ const sendQueuedActuatorState = (param: ActuatorKey, allowWhileDisabled = false)
       // even if the UI is disabled (loading/reboot) so the drain cannot strand.
       if (actuatorsSetQueued.value[param] !== null) {
         sendQueuedActuatorState(param, true)
+      } else {
+        actuatorsSetRollback.value[param] = null
       }
     })
 }
@@ -1302,9 +1366,17 @@ const updateActuatorsState = (param: keyof ActuatorsState, value: number) => {
 
   const key = param as ActuatorKey
 
+  // Capture pre-gesture value once so a failed POST can roll back.
+  if (
+    actuatorsSetQueued.value[key] === null &&
+    !actuatorsSetInFlight.value[key]
+  ) {
+    actuatorsSetRollback.value[key] = actuatorsState.value[key]
+  }
+
   // Optimistic UI update: do not wait for feedback to reflect user input.
   actuatorsState.value[key] = value
-  desiredActuatorsState.value[key] = value
+  armDesiredLatch(key, value)
 
   // Coalesce requests per actuator to prevent backlog.
   const existingQueued = actuatorsSetQueued.value[key]
@@ -1338,6 +1410,7 @@ const getBaseParameters = () => {
 
   const cameraUuid = props.selectedCameraUuid
   const generation = actuatorsRequestGeneration.value
+  const writeSeqAtStart = baseParamWriteSeq
   const payload = {
     camera_uuid: cameraUuid,
     action: "getImageAdjustment",
@@ -1348,7 +1421,9 @@ const getBaseParameters = () => {
       if (
         props.selectedCameraUuid !== cameraUuid ||
         generation !== actuatorsRequestGeneration.value ||
-        inFlightParamWrites.value > 0
+        writeSeqAtStart !== baseParamWriteSeq ||
+        inFlightParamWrites.value > 0 ||
+        dirtyBaseParamFields.size > 0
       ) {
         return
       }

--- a/frontend/src/components/BasicSettings.vue
+++ b/frontend/src/components/BasicSettings.vue
@@ -42,7 +42,7 @@
         </v-btn>
       </div>
       <div
-        v-if="baseParams.auto_awb"
+        v-if="baseParams.auto_awb === BaseAutoWhiteBalanceModeValue.Manual"
         class="d-flex flex-column align-end mt-6"
       >
         <BlueSlider
@@ -1047,7 +1047,10 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
       ) {
         return
       }
-      baseParams.value = data as BaseParameterSetting
+      // Only apply when this is the last in-flight write (avoid older responses clobbering).
+      if (inFlightParamWrites.value === 1) {
+        baseParams.value = data as BaseParameterSetting
+      }
     })
     .catch((error) => {
       const message = `Error sending ${String(param)} control with value '${value}'`
@@ -1266,11 +1269,9 @@ const sendQueuedActuatorState = (param: ActuatorKey, allowWhileDisabled = false)
       // even if the UI is disabled (loading/reboot) so the drain cannot strand.
       if (actuatorsSetQueued.value[param] !== null) {
         sendQueuedActuatorState(param, true)
-      } else {
-        // Clear the desired latch when nothing is queued so whole-percent SERVO
-        // feedback cannot leave a 0.1-step focus value stuck forever.
-        desiredActuatorsState.value[param] = null
       }
+      // Leave desiredActuatorsState latched until SERVO feedback matches
+      // (see applyActuatorsState).
     })
 }
 

--- a/frontend/src/components/BasicSettings.vue
+++ b/frontend/src/components/BasicSettings.vue
@@ -1229,8 +1229,9 @@ const updateActuatorsConfig = (param: keyof ActuatorsParametersConfig, value: an
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const sendQueuedActuatorState = (param: ActuatorKey): void => {
-  if (!props.selectedCameraUuid || props.disabled) return
+const sendQueuedActuatorState = (param: ActuatorKey, allowWhileDisabled = false): void => {
+  if (!props.selectedCameraUuid) return
+  if (props.disabled && !allowWhileDisabled) return
   if (actuatorsSetInFlight.value[param]) return
 
   const value = actuatorsSetQueued.value[param]
@@ -1261,9 +1262,10 @@ const sendQueuedActuatorState = (param: ActuatorKey): void => {
 
       actuatorsSetInFlight.value[param] = false
 
-      // If a newer value was queued while this request was in-flight, send it now.
+      // If a newer value was queued while this request was in-flight, send it now
+      // even if the UI is disabled (loading/reboot) so the drain cannot strand.
       if (actuatorsSetQueued.value[param] !== null) {
-        sendQueuedActuatorState(param)
+        sendQueuedActuatorState(param, true)
       } else {
         // Clear the desired latch when nothing is queued so whole-percent SERVO
         // feedback cannot leave a 0.1-step focus value stuck forever.
@@ -1312,6 +1314,7 @@ const getBaseParameters = () => {
   }
 
   const cameraUuid = props.selectedCameraUuid
+  const generation = actuatorsRequestGeneration.value
   const payload = {
     camera_uuid: cameraUuid,
     action: "getImageAdjustment",
@@ -1319,7 +1322,13 @@ const getBaseParameters = () => {
 
   backendClient.request('POST', '/camera/control', payload)
     .then(data => {
-      if (props.selectedCameraUuid !== cameraUuid) return
+      if (
+        props.selectedCameraUuid !== cameraUuid ||
+        generation !== actuatorsRequestGeneration.value ||
+        inFlightParamWrites.value > 0
+      ) {
+        return
+      }
       baseParams.value = data as BaseParameterSetting
       console.log(data)
     })

--- a/frontend/src/components/BlueSlider.vue
+++ b/frontend/src/components/BlueSlider.vue
@@ -32,7 +32,6 @@
           :class="isEditingCurrentSliderValue ? 'pointer-events-auto' : 'pointer-events-none select-none'"
           :style="{
             left: pillLeft,
-            marginLeft: '5px',
             backgroundColor: color || '#0B5087',
           }"
         >

--- a/frontend/src/components/BlueSlider.vue
+++ b/frontend/src/components/BlueSlider.vue
@@ -359,6 +359,9 @@ const flushPendingValue = (): void => {
 }
 
 const endInteracting = (): void => {
+  window.removeEventListener('pointerup', handlePointerUp)
+  window.removeEventListener('pointercancel', handlePointerCancel)
+  if (!isInteracting.value) return
   isInteracting.value = false
 
   const clamped = Math.min(Math.max(currentSliderValue.value, props.min), props.max)
@@ -376,8 +379,8 @@ const startInteracting = (): void => {
   if (props.disabled || isEditingCurrentSliderValue.value) return
   isInteracting.value = true
   clearCommitLock()
-  window.addEventListener('pointerup', handlePointerUp, { once: true })
-  window.addEventListener('pointercancel', handlePointerCancel, { once: true })
+  window.addEventListener('pointerup', handlePointerUp)
+  window.addEventListener('pointercancel', handlePointerCancel)
 }
 
 const isArrowKey = (key: string): boolean =>

--- a/frontend/src/components/BlueSlider.vue
+++ b/frontend/src/components/BlueSlider.vue
@@ -70,7 +70,6 @@
           type="range"
           class="absolute inset-0 w-full h-full opacity-0"
           :class="disabled ? 'cursor-not-allowed' : 'cursor-pointer'"
-          style="width: 95%; left: 2.5%"
           :min="min"
           :max="max"
           :step="rawStep"
@@ -260,8 +259,10 @@ const approxEqual = (a: number, b: number): boolean => {
 
 // Pill position logic
 const fillWidth = computed(() => {
+  const span = props.max - props.min
+  if (!(span > 0)) return 0
   const val = currentSliderValue.value
-  return ((val - props.min) / (props.max - props.min)) * 100
+  return ((val - props.min) / span) * 100
 })
 const staticFillWidth = ref<number>(0)
 
@@ -271,6 +272,8 @@ const pillLeft = computed(() =>
       ? staticFillWidth.value
       : fillWidth.value) / 100})`
 )
+
+const skipEditCommit = ref(false)
 
 const sendValue = (val: number) => {
   if (val === lastSentValue.value) return
@@ -423,9 +426,11 @@ const onRangeKeyup = (e: KeyboardEvent): void => {
 // Keyboard handling for the edit input.
 const handleValueChange = (e: KeyboardEvent): void => {
   if (e.key === 'Escape') {
-    isEditingCurrentSliderValue.value = false
+    // Restore before leaving edit mode so the edit watcher does not commit.
     editedDisplayValue.value = props.scaleFn ? props.scaleFn(lastSentValue.value) : lastSentValue.value
     currentSliderValue.value = lastSentValue.value
+    skipEditCommit.value = true
+    isEditingCurrentSliderValue.value = false
   } else if (e.key === 'Enter') {
     isEditingCurrentSliderValue.value = false
   }
@@ -468,6 +473,10 @@ watch(isEditingCurrentSliderValue, (isEditing) => {
     editedDisplayValue.value = displayValue.value
     staticFillWidth.value = fillWidth.value
   } else {
+    if (skipEditCommit.value) {
+      skipEditCommit.value = false
+      return
+    }
     if (!Number.isFinite(editedDisplayValue.value)) {
       editedDisplayValue.value = displayValue.value
     }

--- a/frontend/src/components/BlueSlider.vue
+++ b/frontend/src/components/BlueSlider.vue
@@ -276,7 +276,8 @@ const pillLeft = computed(() =>
 const skipEditCommit = ref(false)
 
 const sendValue = (val: number) => {
-  if (val === lastSentValue.value) return
+  const eps = Math.max(1e-6, rawStep.value * 0.25)
+  if (Math.abs(val - lastSentValue.value) <= eps) return
   lastSentValue.value = val
   emit('update:modelValue', val)
 }
@@ -377,6 +378,7 @@ const handlePointerCancel = (): void => endInteracting()
 
 const startInteracting = (): void => {
   if (props.disabled || isEditingCurrentSliderValue.value) return
+  if (isInteracting.value) return
   isInteracting.value = true
   clearCommitLock()
   window.addEventListener('pointerup', handlePointerUp)

--- a/frontend/src/components/ImageTab.vue
+++ b/frontend/src/components/ImageTab.vue
@@ -990,6 +990,7 @@ const doRestoreBase = async () => {
 
   const cameraUuid = props.selectedCameraUuid
   const generation = imageRequestGeneration.value
+  inFlightBaseWrites.value++
   const payload: CameraControl = {
     camera_uuid: cameraUuid,
     action: "setImageAdjustment",
@@ -1014,6 +1015,7 @@ const doRestoreBase = async () => {
     })
     .finally(() => {
       if (generation !== imageRequestGeneration.value) return
+      inFlightBaseWrites.value = Math.max(0, inFlightBaseWrites.value - 1)
       processingBaseRestore.value = false
     })
 }
@@ -1059,6 +1061,7 @@ const doRestoreAdvanced = async () => {
 
   const cameraUuid = props.selectedCameraUuid
   const generation = imageRequestGeneration.value
+  inFlightAdvancedWrites.value++
   const payload: CameraControl = {
     camera_uuid: cameraUuid,
     action: "setImageAdjustmentEx",
@@ -1080,6 +1083,7 @@ const doRestoreAdvanced = async () => {
     })
     .finally(() => {
       if (generation !== imageRequestGeneration.value) return
+      inFlightAdvancedWrites.value = Math.max(0, inFlightAdvancedWrites.value - 1)
       processingAdvancedRestore.value = false
     })
 }

--- a/frontend/src/components/ImageTab.vue
+++ b/frontend/src/components/ImageTab.vue
@@ -854,6 +854,9 @@ const imageRequestGeneration = ref(0)
 /** Monotonic seq so only the newest write/restore may apply its response body. */
 let baseWriteSeq = 0
 let advancedWriteSeq = 0
+/** Fields with an optimistic write that must not be clobbered by WS/GET. */
+const dirtyBaseFields = new Set<keyof BaseParameterSetting>()
+const dirtyAdvancedFields = new Set<keyof AdvancedParameterSetting>()
 
 const applyCameraStateEvent = (body: unknown) => {
   if (!props.selectedCameraUuid) return
@@ -862,11 +865,31 @@ const applyCameraStateEvent = (body: unknown) => {
   const data = body as Record<string, unknown>
   if (data.camera_uuid !== props.selectedCameraUuid) return
 
-  if (data.base_parameters && inFlightBaseWrites.value === 0) {
-    baseParams.value = data.base_parameters as BaseParameterSetting
+  if (data.base_parameters) {
+    const incoming = data.base_parameters as BaseParameterSetting
+    if (dirtyBaseFields.size === 0) {
+      baseParams.value = incoming
+    } else {
+      baseParams.value = {
+        ...incoming,
+        ...Object.fromEntries(
+          [...dirtyBaseFields].map((key) => [key, baseParams.value[key]]),
+        ),
+      } as BaseParameterSetting
+    }
   }
-  if (data.advanced_parameters && inFlightAdvancedWrites.value === 0) {
-    advancedParams.value = data.advanced_parameters as AdvancedParameterSetting
+  if (data.advanced_parameters) {
+    const incoming = data.advanced_parameters as AdvancedParameterSetting
+    if (dirtyAdvancedFields.size === 0) {
+      advancedParams.value = incoming
+    } else {
+      advancedParams.value = {
+        ...incoming,
+        ...Object.fromEntries(
+          [...dirtyAdvancedFields].map((key) => [key, advancedParams.value[key]]),
+        ),
+      } as AdvancedParameterSetting
+    }
   }
 }
 
@@ -880,6 +903,8 @@ watch(
     inFlightAdvancedWrites.value = 0
     baseWriteSeq += 1
     advancedWriteSeq += 1
+    dirtyBaseFields.clear()
+    dirtyAdvancedFields.clear()
     processingWhiteBalance.value = false
     processingBaseRestore.value = false
     processingAdvancedRestore.value = false
@@ -897,6 +922,7 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
   const writeSeq = ++baseWriteSeq
   const previous = baseParams.value[param]
   baseParams.value = { ...baseParams.value, [param]: value }
+  dirtyBaseFields.add(param)
   inFlightBaseWrites.value++
 
   const payload = {
@@ -919,17 +945,21 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
         return
       }
       baseParams.value = data as BaseParameterSetting
+      dirtyBaseFields.clear()
     })
     .catch(error => {
       console.error(`Error sending ${String(param)} control with value '${value}':`, error.message)
       if (
         props.selectedCameraUuid !== cameraUuid ||
-        generation !== imageRequestGeneration.value ||
-        writeSeq !== baseWriteSeq
+        generation !== imageRequestGeneration.value
       ) {
         return
       }
-      baseParams.value = { ...baseParams.value, [param]: previous }
+      // Revert this field even if a newer writeSeq superseded us (other fields).
+      if (baseParams.value[param] === value) {
+        baseParams.value = { ...baseParams.value, [param]: previous }
+      }
+      dirtyBaseFields.delete(param)
     })
     .finally(() => {
       if (generation !== imageRequestGeneration.value) return
@@ -944,6 +974,7 @@ const getBaseParameters = () => {
 
   const cameraUuid = props.selectedCameraUuid
   const generation = imageRequestGeneration.value
+  const writeSeqAtStart = baseWriteSeq
   const payload = {
     camera_uuid: cameraUuid,
     action: "getImageAdjustment",
@@ -954,7 +985,9 @@ const getBaseParameters = () => {
       if (
         props.selectedCameraUuid !== cameraUuid ||
         generation !== imageRequestGeneration.value ||
-        inFlightBaseWrites.value > 0
+        writeSeqAtStart !== baseWriteSeq ||
+        inFlightBaseWrites.value > 0 ||
+        dirtyBaseFields.size > 0
       ) {
         return
       }
@@ -1008,6 +1041,7 @@ const doRestoreBase = async () => {
   const generation = imageRequestGeneration.value
   const writeSeq = ++baseWriteSeq
   inFlightBaseWrites.value++
+  dirtyBaseFields.clear()
   const payload: CameraControl = {
     camera_uuid: cameraUuid,
     action: "setImageAdjustment",
@@ -1027,6 +1061,7 @@ const doRestoreBase = async () => {
         return
       }
       baseParams.value = data as BaseParameterSetting
+      dirtyBaseFields.clear()
     })
     .catch(error => {
       console.error("Error sending base image restore control:", error.message)
@@ -1047,6 +1082,7 @@ const updateAdvancedParam = (param: keyof AdvancedParameterSetting, value: any) 
   const writeSeq = ++advancedWriteSeq
   const previous = advancedParams.value[param]
   advancedParams.value = { ...advancedParams.value, [param]: value }
+  dirtyAdvancedFields.add(param)
   inFlightAdvancedWrites.value++
 
   const payload: CameraControl = {
@@ -1065,17 +1101,20 @@ const updateAdvancedParam = (param: keyof AdvancedParameterSetting, value: any) 
         return
       }
       advancedParams.value = data as AdvancedParameterSetting
+      dirtyAdvancedFields.clear()
     })
     .catch(error => {
       console.error(`Error updating ${param}:`, error.message)
       if (
         props.selectedCameraUuid !== cameraUuid ||
-        generation !== imageRequestGeneration.value ||
-        writeSeq !== advancedWriteSeq
+        generation !== imageRequestGeneration.value
       ) {
         return
       }
-      advancedParams.value = { ...advancedParams.value, [param]: previous }
+      if (advancedParams.value[param] === value) {
+        advancedParams.value = { ...advancedParams.value, [param]: previous }
+      }
+      dirtyAdvancedFields.delete(param)
     })
     .finally(() => {
       if (generation !== imageRequestGeneration.value) return
@@ -1092,6 +1131,7 @@ const doRestoreAdvanced = async () => {
   const generation = imageRequestGeneration.value
   const writeSeq = ++advancedWriteSeq
   inFlightAdvancedWrites.value++
+  dirtyAdvancedFields.clear()
   const payload: CameraControl = {
     camera_uuid: cameraUuid,
     action: "setImageAdjustmentEx",
@@ -1108,6 +1148,7 @@ const doRestoreAdvanced = async () => {
         return
       }
       advancedParams.value = data as AdvancedParameterSetting
+      dirtyAdvancedFields.clear()
     })
     .catch(error => {
       console.error("Error restoring advanced parameters:", error.message)

--- a/frontend/src/components/ImageTab.vue
+++ b/frontend/src/components/ImageTab.vue
@@ -910,7 +910,9 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
       ) {
         return
       }
-      baseParams.value = data as BaseParameterSetting
+      if (inFlightBaseWrites.value === 1) {
+        baseParams.value = data as BaseParameterSetting
+      }
     })
     .catch(error => {
       console.error(`Error sending ${String(param)} control with value '${value}':`, error.message)
@@ -1043,7 +1045,9 @@ const updateAdvancedParam = (param: keyof AdvancedParameterSetting, value: any) 
       ) {
         return
       }
-      advancedParams.value = data as AdvancedParameterSetting
+      if (inFlightAdvancedWrites.value === 1) {
+        advancedParams.value = data as AdvancedParameterSetting
+      }
     })
     .catch(error => {
       console.error(`Error updating ${param}:`, error.message)

--- a/frontend/src/components/ImageTab.vue
+++ b/frontend/src/components/ImageTab.vue
@@ -851,6 +851,9 @@ const antiFlickerOptions = enumToOptions(AdvancedDisplayAntiflickerValue)
 const inFlightBaseWrites = ref(0)
 const inFlightAdvancedWrites = ref(0)
 const imageRequestGeneration = ref(0)
+/** Monotonic seq so only the newest write/restore may apply its response body. */
+let baseWriteSeq = 0
+let advancedWriteSeq = 0
 
 const applyCameraStateEvent = (body: unknown) => {
   if (!props.selectedCameraUuid) return
@@ -875,6 +878,8 @@ watch(
     imageRequestGeneration.value += 1
     inFlightBaseWrites.value = 0
     inFlightAdvancedWrites.value = 0
+    baseWriteSeq += 1
+    advancedWriteSeq += 1
     processingWhiteBalance.value = false
     processingBaseRestore.value = false
     processingAdvancedRestore.value = false
@@ -889,6 +894,8 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
 
   const cameraUuid = props.selectedCameraUuid
   const generation = imageRequestGeneration.value
+  const writeSeq = ++baseWriteSeq
+  const previous = baseParams.value[param]
   baseParams.value = { ...baseParams.value, [param]: value }
   inFlightBaseWrites.value++
 
@@ -906,16 +913,23 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
     .then(data => {
       if (
         props.selectedCameraUuid !== cameraUuid ||
-        generation !== imageRequestGeneration.value
+        generation !== imageRequestGeneration.value ||
+        writeSeq !== baseWriteSeq
       ) {
         return
       }
-      if (inFlightBaseWrites.value === 1) {
-        baseParams.value = data as BaseParameterSetting
-      }
+      baseParams.value = data as BaseParameterSetting
     })
     .catch(error => {
       console.error(`Error sending ${String(param)} control with value '${value}':`, error.message)
+      if (
+        props.selectedCameraUuid !== cameraUuid ||
+        generation !== imageRequestGeneration.value ||
+        writeSeq !== baseWriteSeq
+      ) {
+        return
+      }
+      baseParams.value = { ...baseParams.value, [param]: previous }
     })
     .finally(() => {
       if (generation !== imageRequestGeneration.value) return
@@ -992,6 +1006,7 @@ const doRestoreBase = async () => {
 
   const cameraUuid = props.selectedCameraUuid
   const generation = imageRequestGeneration.value
+  const writeSeq = ++baseWriteSeq
   inFlightBaseWrites.value++
   const payload: CameraControl = {
     camera_uuid: cameraUuid,
@@ -1006,7 +1021,8 @@ const doRestoreBase = async () => {
     .then(data => {
       if (
         props.selectedCameraUuid !== cameraUuid ||
-        generation !== imageRequestGeneration.value
+        generation !== imageRequestGeneration.value ||
+        writeSeq !== baseWriteSeq
       ) {
         return
       }
@@ -1028,6 +1044,8 @@ const updateAdvancedParam = (param: keyof AdvancedParameterSetting, value: any) 
 
   const cameraUuid = props.selectedCameraUuid
   const generation = imageRequestGeneration.value
+  const writeSeq = ++advancedWriteSeq
+  const previous = advancedParams.value[param]
   advancedParams.value = { ...advancedParams.value, [param]: value }
   inFlightAdvancedWrites.value++
 
@@ -1041,16 +1059,23 @@ const updateAdvancedParam = (param: keyof AdvancedParameterSetting, value: any) 
     .then(data => {
       if (
         props.selectedCameraUuid !== cameraUuid ||
-        generation !== imageRequestGeneration.value
+        generation !== imageRequestGeneration.value ||
+        writeSeq !== advancedWriteSeq
       ) {
         return
       }
-      if (inFlightAdvancedWrites.value === 1) {
-        advancedParams.value = data as AdvancedParameterSetting
-      }
+      advancedParams.value = data as AdvancedParameterSetting
     })
     .catch(error => {
       console.error(`Error updating ${param}:`, error.message)
+      if (
+        props.selectedCameraUuid !== cameraUuid ||
+        generation !== imageRequestGeneration.value ||
+        writeSeq !== advancedWriteSeq
+      ) {
+        return
+      }
+      advancedParams.value = { ...advancedParams.value, [param]: previous }
     })
     .finally(() => {
       if (generation !== imageRequestGeneration.value) return
@@ -1065,6 +1090,7 @@ const doRestoreAdvanced = async () => {
 
   const cameraUuid = props.selectedCameraUuid
   const generation = imageRequestGeneration.value
+  const writeSeq = ++advancedWriteSeq
   inFlightAdvancedWrites.value++
   const payload: CameraControl = {
     camera_uuid: cameraUuid,
@@ -1076,7 +1102,8 @@ const doRestoreAdvanced = async () => {
     .then(data => {
       if (
         props.selectedCameraUuid !== cameraUuid ||
-        generation !== imageRequestGeneration.value
+        generation !== imageRequestGeneration.value ||
+        writeSeq !== advancedWriteSeq
       ) {
         return
       }

--- a/frontend/src/components/Slider.vue
+++ b/frontend/src/components/Slider.vue
@@ -56,10 +56,9 @@ let sliderInterval: number | null = null
 let isSliding = false
 
 watch(() => props.current, (newVal) => {
+  if (isSliding) return
   current.value = newVal
-  if (!isSliding) {
-    lastSentValue.value = newVal
-  }
+  lastSentValue.value = newVal
 })
 
 onBeforeUnmount(() => {

--- a/frontend/src/components/Slider.vue
+++ b/frontend/src/components/Slider.vue
@@ -92,7 +92,7 @@ const onNumberCommit = () => {
 }
 
 const startSliding = () => {
-  if (isSliding) return
+  if (props.disabled || isSliding) return
   isSliding = true
   window.addEventListener('pointerup', stopSliding)
   window.addEventListener('pointercancel', stopSliding)

--- a/frontend/src/components/Slider.vue
+++ b/frontend/src/components/Slider.vue
@@ -10,10 +10,7 @@
       :step="step"
       :disabled="disabled"
       hide-details
-      @mousedown="startSliding"
-      @touchstart.passive="startSliding"
-      @mouseup="stopSliding"
-      @touchend="stopSliding"
+      @pointerdown="startSliding"
       @input="onSliderInput"
     >
       <template #append>
@@ -25,6 +22,9 @@
           width="90px"
           hide-details
           single-line
+          :disabled="disabled"
+          @change="onNumberCommit"
+          @blur="onNumberCommit"
         />
       </template>
     </v-slider>
@@ -44,7 +44,7 @@ const props = withDefaults(defineProps<{
   disabled?: boolean
 }>(), {
   step: 1,
-  disabbled: false
+  disabled: false
 })
 
 const current = ref(props.current)
@@ -62,6 +62,8 @@ watch(() => props.current, (newVal) => {
 })
 
 onBeforeUnmount(() => {
+  window.removeEventListener('pointerup', stopSliding)
+  window.removeEventListener('pointercancel', stopSliding)
   if (sliderInterval) {
     clearInterval(sliderInterval)
     sliderInterval = null
@@ -84,8 +86,16 @@ const onSliderInput = () => {
 
 }
 
+const onNumberCommit = () => {
+  current.value = Math.min(Math.max(current.value, props.min), props.max)
+  sendValue(current.value)
+}
+
 const startSliding = () => {
+  if (isSliding) return
   isSliding = true
+  window.addEventListener('pointerup', stopSliding)
+  window.addEventListener('pointercancel', stopSliding)
   if (!sliderInterval) {
     sliderInterval = setInterval(() => {
       if (isSliding) {
@@ -96,7 +106,10 @@ const startSliding = () => {
 }
 
 const stopSliding = () => {
+  if (!isSliding) return
   isSliding = false
+  window.removeEventListener('pointerup', stopSliding)
+  window.removeEventListener('pointercancel', stopSliding)
   if (sliderInterval) {
     clearInterval(sliderInterval)
     sliderInterval = null

--- a/frontend/src/components/StreamsTab.vue
+++ b/frontend/src/components/StreamsTab.vue
@@ -160,6 +160,8 @@ const hasUserEditedVideo = ref(false)
 const streamsRequestGeneration = ref(0)
 let suppressUserEditFlag = false
 let awaitingHydrate = false
+/** Ignore camera/state venc pushes until reboot overlay clears. */
+let awaitingRestartHydrate = false
 
 watch(
   () => props.selectedCameraUuid,
@@ -167,6 +169,7 @@ watch(
     streamsRequestGeneration.value += 1
     hasUserEditedVideo.value = false
     processingUpdate.value = false
+    awaitingRestartHydrate = false
     // Hold dirty latch until the first successful hydrate for this camera.
     suppressUserEditFlag = true
     awaitingHydrate = true
@@ -179,6 +182,15 @@ watch(
     getVideoParameters(true)
   },
   { immediate: true },
+)
+
+watch(
+  () => props.disabled,
+  (disabled, wasDisabled) => {
+    if (wasDisabled && !disabled && awaitingRestartHydrate) {
+      awaitingRestartHydrate = false
+    }
+  },
 )
 
 watch(
@@ -217,7 +229,7 @@ const applyCameraStateEvent = (body: unknown) => {
   const data = body as Record<string, unknown>
   if (data.camera_uuid !== props.selectedCameraUuid) return
   if (!data.video_parameters) return
-  if (hasUserEditedVideo.value) return
+  if (hasUserEditedVideo.value || awaitingRestartHydrate) return
 
   const settings = data.video_parameters as VideoParameterSettings
   const currentChannel = selectedVideoParameters.value.channel ?? VideoChannelValue.MainStream
@@ -271,6 +283,7 @@ const updateVideoParameters = () => {
         // Always reboot the camera that accepted the venc change, even if the
         // user switched selection afterward.
         handedOffRestart = true
+        awaitingRestartHydrate = true
         doRestart(cameraUuid)
       }
     })
@@ -394,8 +407,8 @@ const update_video_parameter_values = (settings: VideoParameterSettings) => {
   selectedVideoParameters.value.pixel_list = undefined
 
   selectedVideoResolution.value = {
-    width: settings.pic_width!,
-    height: settings.pic_height!,
+    width: settings.pic_width ?? selectedVideoResolution.value?.width ?? 0,
+    height: settings.pic_height ?? selectedVideoResolution.value?.height ?? 0,
   } as VideoResolutionValue
   hasUserEditedVideo.value = false
   awaitingHydrate = false

--- a/frontend/src/components/StreamsTab.vue
+++ b/frontend/src/components/StreamsTab.vue
@@ -162,6 +162,32 @@ let suppressUserEditFlag = false
 let awaitingHydrate = false
 /** Ignore camera/state venc pushes until reboot overlay clears. */
 let awaitingRestartHydrate = false
+/** Fallback so awaitingRestartHydrate cannot stick if disabled never flips. */
+let restartHydrateTimeout: number | null = null
+const RESTART_HYDRATE_TIMEOUT_MS = 30_000
+
+const clearRestartHydrateLatch = (): void => {
+  awaitingRestartHydrate = false
+  if (restartHydrateTimeout !== null) {
+    clearTimeout(restartHydrateTimeout)
+    restartHydrateTimeout = null
+  }
+}
+
+const armRestartHydrateLatch = (): void => {
+  clearRestartHydrateLatch()
+  awaitingRestartHydrate = true
+  const generation = streamsRequestGeneration.value
+  restartHydrateTimeout = window.setTimeout(() => {
+    restartHydrateTimeout = null
+    if (
+      awaitingRestartHydrate &&
+      generation === streamsRequestGeneration.value
+    ) {
+      awaitingRestartHydrate = false
+    }
+  }, RESTART_HYDRATE_TIMEOUT_MS)
+}
 
 watch(
   () => props.selectedCameraUuid,
@@ -169,7 +195,7 @@ watch(
     streamsRequestGeneration.value += 1
     hasUserEditedVideo.value = false
     processingUpdate.value = false
-    awaitingRestartHydrate = false
+    clearRestartHydrateLatch()
     // Hold dirty latch until the first successful hydrate for this camera.
     suppressUserEditFlag = true
     awaitingHydrate = true
@@ -187,8 +213,9 @@ watch(
 watch(
   () => props.disabled,
   (disabled, wasDisabled) => {
+    // Overlay cleared — re-fetch and clear latch only after a successful hydrate.
     if (wasDisabled && !disabled && awaitingRestartHydrate) {
-      awaitingRestartHydrate = false
+      getVideoParameters(true)
     }
   },
 )
@@ -229,7 +256,13 @@ const applyCameraStateEvent = (body: unknown) => {
   const data = body as Record<string, unknown>
   if (data.camera_uuid !== props.selectedCameraUuid) return
   if (!data.video_parameters) return
-  if (hasUserEditedVideo.value || awaitingRestartHydrate) return
+  if (hasUserEditedVideo.value) return
+  if (awaitingRestartHydrate) {
+    // First post-restart video snapshot — accept and clear the latch.
+    update_video_parameter_values(data.video_parameters as VideoParameterSettings)
+    clearRestartHydrateLatch()
+    return
+  }
 
   const settings = data.video_parameters as VideoParameterSettings
   const currentChannel = selectedVideoParameters.value.channel ?? VideoChannelValue.MainStream
@@ -288,7 +321,7 @@ const updateVideoParameters = () => {
           props.selectedCameraUuid === cameraUuid &&
           generation === streamsRequestGeneration.value
         ) {
-          awaitingRestartHydrate = true
+          armRestartHydrateLatch()
         }
       }
     })
@@ -349,7 +382,7 @@ const doRestart = (cameraUuid?: string) => {
         error.message
       )
       if (generation === streamsRequestGeneration.value) {
-        awaitingRestartHydrate = false
+        clearRestartHydrateLatch()
       }
     })
     .finally(() => {
@@ -390,6 +423,9 @@ const getVideoParameters = (update: boolean) => {
 
       if (update) {
         update_video_parameter_values(settings)
+        if (awaitingRestartHydrate) {
+          clearRestartHydrateLatch()
+        }
       }
     })
     .catch((error) => {

--- a/frontend/src/components/StreamsTab.vue
+++ b/frontend/src/components/StreamsTab.vue
@@ -260,22 +260,19 @@ const updateVideoParameters = () => {
   backendClient
     .request('POST', '/camera/control', payload)
     .then((data) => {
+      if (
+        props.selectedCameraUuid === cameraUuid &&
+        generation === streamsRequestGeneration.value
+      ) {
+        // Clear dirty latch / sync downloaded* even when we also reboot.
+        update_video_parameter_values(data as VideoParameterSettings)
+      }
       if (shouldRestart) {
         // Always reboot the camera that accepted the venc change, even if the
         // user switched selection afterward.
         handedOffRestart = true
         doRestart(cameraUuid)
-        return
       }
-      if (
-        props.selectedCameraUuid !== cameraUuid ||
-        generation !== streamsRequestGeneration.value
-      ) {
-        return
-      }
-      const settings: VideoParameterSettings =
-        data as VideoParameterSettings
-      update_video_parameter_values(settings)
     })
     .catch((error) =>
       console.error(

--- a/frontend/src/components/StreamsTab.vue
+++ b/frontend/src/components/StreamsTab.vue
@@ -283,8 +283,13 @@ const updateVideoParameters = () => {
         // Always reboot the camera that accepted the venc change, even if the
         // user switched selection afterward.
         handedOffRestart = true
-        awaitingRestartHydrate = true
         doRestart(cameraUuid)
+        if (
+          props.selectedCameraUuid === cameraUuid &&
+          generation === streamsRequestGeneration.value
+        ) {
+          awaitingRestartHydrate = true
+        }
       }
     })
     .catch((error) =>
@@ -338,12 +343,15 @@ const doRestart = (cameraUuid?: string) => {
       }
       console.log("Got an answer from the restarting request", data)
     })
-    .catch((error) =>
+    .catch((error) => {
       console.error(
         `Error sending restart':`,
         error.message
       )
-    )
+      if (generation === streamsRequestGeneration.value) {
+        awaitingRestartHydrate = false
+      }
+    })
     .finally(() => {
       if (!manageSpinner) return
       if (generation !== streamsRequestGeneration.value) return

--- a/frontend/src/utils/backendClient.ts
+++ b/frontend/src/utils/backendClient.ts
@@ -478,6 +478,7 @@ class BackendClient {
   /** Re-push subscribe for the active camera without changing refcounts (tab remount). */
   refreshCameraSubscription(): void {
     if (this.subscribedCameraUuid) {
+      this.subscribeBlocked = false
       this.queueSubscribe(this.subscribedCameraUuid)
     }
   }

--- a/frontend/src/utils/backendClient.ts
+++ b/frontend/src/utils/backendClient.ts
@@ -102,6 +102,8 @@ class BackendClient {
   private hasCameraState = false
   /** Re-subscribe on next camera/list only after unknown_camera rejection. */
   private subscribeNeedsRetry = false
+  /** Hard-stop list retries after camera_cap until the user re-selects. */
+  private subscribeBlocked = false
 
   private wsUrl(): string {
     const url = new URL('v1/ws', window.location.href)
@@ -327,7 +329,9 @@ class BackendClient {
       // Re-subscribe after MCM list arrives only when we still need state
       // (boot race) or the last reject was unknown_camera — not on every list churn.
       if (message.event === 'camera/list' && this.subscribedCameraUuid) {
-        if (!this.hasCameraState || this.subscribeNeedsRetry) {
+        if (this.subscribeBlocked) {
+          // Over capacity — wait for an explicit subscribeCamera (user action).
+        } else if (!this.hasCameraState || this.subscribeNeedsRetry) {
           this.queueSubscribe(this.subscribedCameraUuid)
         }
       }
@@ -337,7 +341,10 @@ class BackendClient {
           if (body?.reason === 'unknown_camera') {
             // Retry from the next camera/list — do not immediate-resubscribe (storm).
             this.subscribeNeedsRetry = true
+            this.subscribeBlocked = false
           } else if (body?.reason === 'camera_cap') {
+            this.subscribeBlocked = true
+            this.subscribeNeedsRetry = false
             this.notifyWarning('Camera subscribe rejected: camera limit reached')
           } else {
             console.warn('Camera subscribe rejected:', body?.reason ?? 'unknown')
@@ -462,6 +469,7 @@ class BackendClient {
     this.subscribedCameraUuid = cameraUuid
     this.hasCameraState = false
     this.subscribeNeedsRetry = false
+    this.subscribeBlocked = false
     // Always send subscribe so the backend re-pushes UI + snapshot for this
     // consumer (refcount > 0 alone used to skip the frame and leave remounts blank).
     this.queueSubscribe(cameraUuid)

--- a/frontend/src/utils/backendClient.ts
+++ b/frontend/src/utils/backendClient.ts
@@ -240,6 +240,8 @@ class BackendClient {
         this.connectPromise = null
         this.stopStaleCheck()
         this.setConnectionState('disconnected')
+        // Force list-driven re-subscribe after reconnect — prior state may be gone.
+        this.hasCameraState = false
         this.rejectAllPending(new Error('WebSocket closed'))
 
         if (!settled) {
@@ -478,7 +480,7 @@ class BackendClient {
   /** Re-push subscribe for the active camera without changing refcounts (tab remount). */
   refreshCameraSubscription(): void {
     if (this.subscribedCameraUuid) {
-      this.subscribeBlocked = false
+      // Do not clear subscribeBlocked — tab remount must not retry past camera_cap.
       this.queueSubscribe(this.subscribedCameraUuid)
     }
   }

--- a/frontend/src/utils/backendClient.ts
+++ b/frontend/src/utils/backendClient.ts
@@ -121,6 +121,10 @@ class BackendClient {
   private notifyTransportError(error: unknown): void {
     if (!isTransportError(error)) return
     const message = transportErrorMessage(error)
+    this.notifyWarning(message)
+  }
+
+  private notifyWarning(message: string): void {
     for (const handler of this.transportErrorHandlers) {
       handler(message)
     }
@@ -331,8 +335,10 @@ class BackendClient {
         const body = message.body as { camera_uuid?: string; reason?: string } | null
         if (!body?.camera_uuid || body.camera_uuid === this.subscribedCameraUuid) {
           if (body?.reason === 'unknown_camera') {
+            // Retry from the next camera/list — do not immediate-resubscribe (storm).
             this.subscribeNeedsRetry = true
-            this.queueSubscribe(this.subscribedCameraUuid)
+          } else if (body?.reason === 'camera_cap') {
+            this.notifyWarning('Camera subscribe rejected: camera limit reached')
           } else {
             console.warn('Camera subscribe rejected:', body?.reason ?? 'unknown')
           }

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -535,8 +535,10 @@ watch(warningToastMessage, (message, _previous, onCleanup) => {
   if (!message) return
 
   const cameraUuid = selectedCameraUUID.value
-  const backendOwned =
-    cameraUuid != null && !!uiByCamera.get(cameraUuid)?.warning_toast
+  const cachedToast =
+    cameraUuid != null ? uiByCamera.get(cameraUuid)?.warning_toast ?? null : null
+  // Only auto-dismissUi when the displayed text is the backend-owned toast.
+  const backendOwned = cachedToast != null && cachedToast === message
   const timeout = setTimeout(() => {
     if (backendOwned && cameraUuid) {
       backendClient.dismissUi(cameraUuid, 'warning_toast')


### PR DESCRIPTION
## Summary
Split from the websockets work: **Harden dirty latch, Escape, focus, and rollback hydrate**.

Commits in this slice:
- `frontend: Fix venc dirty latch, subscribe storm, and BlueSlider pill fit`
- `frontend: Fix Escape commit, slider sync, and subscribe cap storms`
- `frontend: Fix focus latch epsilon, write sequencing, and restart hydrate`
- `frontend: Harden WS dirty merges, restart hydrate, and actuator rollback`

## Stack
- Part **16/24** of the websockets split (all PRs target `master`)
- Depends on https://github.com/bluerobotics/radcam-manager/pull/216 merging first.
- After the previous stack PR merges: rebase this branch onto `master` and `git push --force-with-lease`
- Intermediate slices may show **red CI** (incomplete stack / missing later fixes). That is expected.
- The batch is only done when tip **[#225](https://github.com/bluerobotics/radcam-manager/pull/225)** (`24/24`) is green after the full merge-rebase dance.

## Test plan
- [ ] Dirty video/encoder fields are not clobbered by unrelated `camera/state` patches while editing
- [ ] Escape commits/cancels slider edit as intended; remote updates do not fight an open edit
- [ ] Focus latch tolerates percent quantization; actuator rollback only when the matching in-flight token is active
