### PR TITLE
websockets 17/24: MAVLink txn mutex and slim static MANAGER

### DIFF
--- a/backend/libs/autopilot/src/actuators_watch.rs
+++ b/backend/libs/autopilot/src/actuators_watch.rs
@@ -396,20 +396,18 @@ async fn actuators_watcher() {
 
 #[instrument(level = "debug", skip_all)]
 async fn open_receiver() -> Option<(broadcast::Receiver<Message>, u8)> {
-    let manager = MANAGER.get()?.read().await;
-    let receiver = manager.mavlink.get_receiver().await;
-    let target_system = manager.mavlink.inner.system_id;
+    let mavlink = crate::mavlink::component().ok()?;
+    let receiver = mavlink.get_receiver().await;
+    let target_system = mavlink.system_id();
     Some((receiver, target_system))
 }
 
 #[instrument(level = "debug")]
 async fn request_servo_stream(interval_us: f32) {
-    let Some(manager) = MANAGER.get() else {
+    let Ok(mavlink) = crate::mavlink::component() else {
         return;
     };
-    let manager = manager.read().await;
-    if let Err(error) = manager
-        .mavlink
+    if let Err(error) = mavlink
         .set_message_interval(SERVO_OUTPUT_RAW_DATA::ID, interval_us)
         .await
     {

--- a/backend/libs/autopilot/src/manager/camera.rs
+++ b/backend/libs/autopilot/src/manager/camera.rs
@@ -25,13 +25,15 @@ impl Manager {
                 .entry(*camera_uuid)
                 .or_default()
                 .parameters;
-            let encoding = self.mavlink.encoding().await;
+            let encoding = crate::mavlink::component()?.encoding().await;
 
             // Disables the old camera_id:
             if &current_parameters.camera_id != camera_id {
                 let param_name = format!("CAM{}_TYPE", current_parameters.camera_id as u8);
 
-                let mut param = self.mavlink.get_param(&param_name, false).await?;
+                let mut param = crate::mavlink::component()?
+                    .get_param(&param_name, false)
+                    .await?;
                 let old_value = param.value;
                 param
                     .value
@@ -39,7 +41,7 @@ impl Manager {
                 let new_value = param.value;
 
                 if old_value != new_value {
-                    match self.mavlink.set_param(param).await {
+                    match crate::mavlink::component()?.set_param(param).await {
                         Ok(_) => {
                             if old_value != new_value {
                                 info!(
@@ -62,7 +64,9 @@ impl Manager {
             {
                 let param_name = format!("CAM{}_TYPE", *camera_id as u8);
 
-                let mut param = self.mavlink.get_param(&param_name, false).await?;
+                let mut param = crate::mavlink::component()?
+                    .get_param(&param_name, false)
+                    .await?;
                 let old_value = param.value;
                 param
                     .value
@@ -70,7 +74,7 @@ impl Manager {
                 let new_value = param.value;
 
                 if overwrite || old_value != new_value {
-                    match self.mavlink.set_param(param).await {
+                    match crate::mavlink::component()?.set_param(param).await {
                         Ok(_) => {
                             if overwrite || old_value != new_value {
                                 info!(

--- a/backend/libs/autopilot/src/manager/focus.rs
+++ b/backend/libs/autopilot/src/manager/focus.rs
@@ -25,14 +25,16 @@ impl Manager {
                 .entry(*camera_uuid)
                 .or_default()
                 .parameters;
-            let encoding = self.mavlink.encoding().await;
+            let encoding = crate::mavlink::component()?.encoding().await;
 
             // Disables the old focus_channel:
             if &current_parameters.focus_channel != channel {
                 let param_name =
                     format!("SERVO{}_FUNCTION", current_parameters.focus_channel as u8);
 
-                let mut param = self.mavlink.get_param(&param_name, false).await?;
+                let mut param = crate::mavlink::component()?
+                    .get_param(&param_name, false)
+                    .await?;
                 let old_value = param.value;
                 param
                     .value
@@ -40,7 +42,7 @@ impl Manager {
                 let new_value = param.value;
 
                 if old_value != new_value {
-                    match self.mavlink.set_param(param).await {
+                    match crate::mavlink::component()?.set_param(param).await {
                         Ok(_) => {
                             if old_value != new_value {
                                 info!(
@@ -73,7 +75,9 @@ impl Manager {
                             )
                         })?;
 
-                let mut param = self.mavlink.get_param(&param_name, false).await?;
+                let mut param = crate::mavlink::component()?
+                    .get_param(&param_name, false)
+                    .await?;
                 let old_value = param.value;
                 param
                     .value
@@ -81,7 +85,7 @@ impl Manager {
                 let new_value = param.value;
 
                 if overwrite || old_value != new_value {
-                    match self.mavlink.set_param(param).await {
+                    match crate::mavlink::component()?.set_param(param).await {
                         Ok(_) => {
                             if overwrite || old_value != new_value {
                                 info!(

--- a/backend/libs/autopilot/src/manager/macros.rs
+++ b/backend/libs/autopilot/src/manager/macros.rs
@@ -15,53 +15,56 @@ macro_rules! generate_update_channel_param_function {
             parameters: &$crate::api::ActuatorsParametersConfig,
             force_apply: bool,
         ) -> Result<()> {
-            let current_parameters = &mut self
-                .settings
-                .actuators
-                .entry(*camera_uuid)
-                .or_default()
-                .parameters;
-
-            let encoding = $crate::mavlink::component()?.encoding().await;
-
-            let channel = current_parameters.$channel_field as u8;
-
-            let param_name = format!("{}{}_{}", $param_prefix, channel, $param_suffix);
-
-            let new_value = match (parameters.$field_name, force_apply) {
-                (Some(value), _) => value,
-                (None, true) => current_parameters.$field_name,
-                (None, false) => return Ok(()),
+            // Snapshot under &mut self with no await, then release the field borrow
+            // before MAVLink I/O (caller must not hold MANAGER.write across this).
+            let (param_name, new_value, old_value) = {
+                let current_parameters = &mut self
+                    .settings
+                    .actuators
+                    .entry(*camera_uuid)
+                    .or_default()
+                    .parameters;
+                let channel = current_parameters.$channel_field as u8;
+                let param_name = format!("{}{}_{}", $param_prefix, channel, $param_suffix);
+                let new_value = match (parameters.$field_name, force_apply) {
+                    (Some(value), _) => value,
+                    (None, true) => current_parameters.$field_name,
+                    (None, false) => return Ok(()),
+                };
+                let old_value = current_parameters.$field_name;
+                (param_name, new_value, old_value)
             };
 
-            let mut param = $crate::mavlink::component()?
-                .get_param(&param_name, false)
-                .await?;
-            let old_value = current_parameters.$field_name;
+            if (old_value == new_value) && !force_apply {
+                trace!("Parameter {param_name:?} skipped");
+                return Ok(());
+            }
+
+            let mavlink = $crate::mavlink::component()?;
+            let encoding = mavlink.encoding().await;
+            let mut param = mavlink.get_param(&param_name, false).await?;
             param.value.set_value(ParamType::$ty(new_value), encoding)?;
 
-            if (old_value != new_value) || force_apply {
-                match $crate::mavlink::component()?.set_param(param).await {
-                    Ok(_) => {
-                        if old_value != new_value {
-                            info!(
-                                "{} changed from {:?} to {:?}",
-                                stringify!($field_name),
-                                old_value,
-                                new_value
-                            );
-                        }
-                        current_parameters.$field_name = new_value;
+            match mavlink.set_param(param).await {
+                Ok(_) => {
+                    if old_value != new_value {
+                        info!(
+                            "{} changed from {:?} to {:?}",
+                            stringify!($field_name),
+                            old_value,
+                            new_value
+                        );
                     }
-                    Err(error) => {
-                        return Err(anyhow::anyhow!(
-                            "Failed setting parameter {}: {error:?}",
-                            stringify!($field_name)
-                        ));
+                    if let Some(actuators) = self.settings.actuators.get_mut(camera_uuid) {
+                        actuators.parameters.$field_name = new_value;
                     }
                 }
-            } else {
-                trace!("Parameter {param_name:?} skipped");
+                Err(error) => {
+                    return Err(anyhow::anyhow!(
+                        "Failed setting parameter {}: {error:?}",
+                        stringify!($field_name)
+                    ));
+                }
             }
 
             Ok(())
@@ -84,60 +87,57 @@ macro_rules! generate_update_mount_param_function {
             parameters: &$crate::api::ActuatorsParametersConfig,
             force_apply: bool,
         ) -> Result<bool> {
-            let current_parameters = &mut self
-                .settings
-                .actuators
-                .entry(*camera_uuid)
-                .or_default()
-                .parameters;
-            let mut has_changed = false;
-
-            let encoding = $crate::mavlink::component()?.encoding().await;
-
-            let mount_id = match current_parameters.camera_id {
-                api::CameraID::CAM1 => TiltChannelFunction::MNT1,
-                api::CameraID::CAM2 => TiltChannelFunction::MNT2,
+            let (param_name, new_value, old_value) = {
+                let current_parameters = &mut self
+                    .settings
+                    .actuators
+                    .entry(*camera_uuid)
+                    .or_default()
+                    .parameters;
+                let mount_id = match current_parameters.camera_id {
+                    api::CameraID::CAM1 => TiltChannelFunction::MNT1,
+                    api::CameraID::CAM2 => TiltChannelFunction::MNT2,
+                };
+                let param_name = format!("{mount_id:?}_{}", $param_suffix);
+                let new_value = match (parameters.$field_name, force_apply) {
+                    (Some(value), _) => value,
+                    (None, true) => current_parameters.$field_name,
+                    (None, false) => return Ok(false),
+                };
+                let old_value = current_parameters.$field_name;
+                (param_name, new_value, old_value)
             };
-            let param_name = format!("{mount_id:?}_{}", $param_suffix);
 
-            let new_value = match (parameters.$field_name, force_apply) {
-                (Some(value), _) => value,
-                (None, true) => current_parameters.$field_name,
-                (None, false) => return Ok(has_changed),
-            };
-
-            let mut param = $crate::mavlink::component()?
-                .get_param(&param_name, false)
-                .await?;
-            let old_value = current_parameters.$field_name;
-            param.value.set_value(ParamType::$ty(new_value), encoding)?;
-
-            if (old_value != new_value) || force_apply {
-                match $crate::mavlink::component()?.set_param(param).await {
-                    Ok(_) => {
-                        if old_value != new_value {
-                            info!(
-                                "{} changed from {:?} to {:?}",
-                                stringify!($field_name),
-                                old_value,
-                                new_value
-                            );
-                        }
-                        current_parameters.$field_name = new_value;
-                        has_changed = true;
-                    }
-                    Err(error) => {
-                        return Err(anyhow::anyhow!(
-                            "Failed setting parameter {}: {error:?}",
-                            stringify!($field_name)
-                        ));
-                    }
-                }
-            } else {
+            if (old_value == new_value) && !force_apply {
                 trace!("Parameter {param_name:?} skipped");
+                return Ok(false);
             }
 
-            Ok(has_changed)
+            let mavlink = $crate::mavlink::component()?;
+            let encoding = mavlink.encoding().await;
+            let mut param = mavlink.get_param(&param_name, false).await?;
+            param.value.set_value(ParamType::$ty(new_value), encoding)?;
+
+            match mavlink.set_param(param).await {
+                Ok(_) => {
+                    if old_value != new_value {
+                        info!(
+                            "{} changed from {:?} to {:?}",
+                            stringify!($field_name),
+                            old_value,
+                            new_value
+                        );
+                    }
+                    if let Some(actuators) = self.settings.actuators.get_mut(camera_uuid) {
+                        actuators.parameters.$field_name = new_value;
+                    }
+                    Ok(old_value != new_value)
+                }
+                Err(error) => Err(anyhow::anyhow!(
+                    "Failed setting parameter {}: {error:?}",
+                    stringify!($field_name)
+                )),
+            }
         }
     };
 }

--- a/backend/libs/autopilot/src/manager/macros.rs
+++ b/backend/libs/autopilot/src/manager/macros.rs
@@ -22,7 +22,7 @@ macro_rules! generate_update_channel_param_function {
                 .or_default()
                 .parameters;
 
-            let encoding = self.mavlink.encoding().await;
+            let encoding = $crate::mavlink::component()?.encoding().await;
 
             let channel = current_parameters.$channel_field as u8;
 
@@ -34,12 +34,14 @@ macro_rules! generate_update_channel_param_function {
                 (None, false) => return Ok(()),
             };
 
-            let mut param = self.mavlink.get_param(&param_name, false).await?;
+            let mut param = $crate::mavlink::component()?
+                .get_param(&param_name, false)
+                .await?;
             let old_value = current_parameters.$field_name;
             param.value.set_value(ParamType::$ty(new_value), encoding)?;
 
             if (old_value != new_value) || force_apply {
-                match self.mavlink.set_param(param).await {
+                match $crate::mavlink::component()?.set_param(param).await {
                     Ok(_) => {
                         if old_value != new_value {
                             info!(
@@ -90,7 +92,7 @@ macro_rules! generate_update_mount_param_function {
                 .parameters;
             let mut has_changed = false;
 
-            let encoding = self.mavlink.encoding().await;
+            let encoding = $crate::mavlink::component()?.encoding().await;
 
             let mount_id = match current_parameters.camera_id {
                 api::CameraID::CAM1 => TiltChannelFunction::MNT1,
@@ -104,12 +106,14 @@ macro_rules! generate_update_mount_param_function {
                 (None, false) => return Ok(has_changed),
             };
 
-            let mut param = self.mavlink.get_param(&param_name, false).await?;
+            let mut param = $crate::mavlink::component()?
+                .get_param(&param_name, false)
+                .await?;
             let old_value = current_parameters.$field_name;
             param.value.set_value(ParamType::$ty(new_value), encoding)?;
 
             if (old_value != new_value) || force_apply {
-                match self.mavlink.set_param(param).await {
+                match $crate::mavlink::component()?.set_param(param).await {
                     Ok(_) => {
                         if old_value != new_value {
                             info!(

--- a/backend/libs/autopilot/src/manager/mod.rs
+++ b/backend/libs/autopilot/src/manager/mod.rs
@@ -25,6 +25,10 @@ use crate::{
 
 pub static MANAGER: OnceCell<RwLock<Manager>> = OnceCell::new();
 
+/// Serializes config apply/reset/clear. Watcher never takes this.
+/// Lock order: CONFIG_APPLY → MANAGER → mavlink txn.
+pub static CONFIG_APPLY: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 #[derive(Debug)]
 pub struct Manager {
     pub autopilot_scripts_file: String,
@@ -58,18 +62,20 @@ impl State {
 
     #[instrument(level = "debug", skip(self))]
     pub async fn save(&self) -> Result<()> {
+        // Clone under the caller's MANAGER guard, then drop any implication that
+        // disk I/O needs the actuators map borrow — SETTINGS_MANAGER is separate.
+        let actuators = self
+            .actuators
+            .iter()
+            .map(|(uuid, actuator_settings)| (*uuid, actuator_settings.into()))
+            .collect();
+
         let settings = &mut SETTINGS_MANAGER
             .get()
             .context("Not available")?
             .write()
             .await
             .settings;
-
-        let actuators = self
-            .actuators
-            .iter()
-            .map(|(uuid, actuator_settings)| (*uuid, actuator_settings.into()))
-            .collect();
 
         *settings.get_actuators_mut() = actuators;
 
@@ -231,6 +237,7 @@ pub async fn init(
     let settings = State::from_settings().await?;
 
     if let Some(manager) = MANAGER.get() {
+        let _apply = CONFIG_APPLY.lock().await;
         let mut guard = manager.write().await;
         guard.autopilot_scripts_file = autopilot_scripts_file;
         guard.settings = settings;
@@ -260,6 +267,7 @@ pub async fn init(
 pub async fn clear_saved_settings() -> Result<()> {
     settings::clear().await?;
 
+    let _apply = CONFIG_APPLY.lock().await;
     let manager = MANAGER.get().context("Not available")?;
     let mut guard = manager.write().await;
     guard.remove_script().await?;

--- a/backend/libs/autopilot/src/manager/mod.rs
+++ b/backend/libs/autopilot/src/manager/mod.rs
@@ -79,57 +79,6 @@ impl State {
 }
 
 impl Manager {
-    #[allow(dead_code)] // Convenience when the caller already holds MANAGER.write().
-    #[instrument(level = "debug", skip(self))]
-    pub async fn get_state(&mut self, camera_uuid: &Uuid) -> Result<api::ActuatorsState> {
-        let actuators = self
-            .settings
-            .actuators
-            .get_mut(camera_uuid)
-            .context(crate::ACTUATORS_NOT_CONFIGURED)?;
-
-        let servo_output_raw = self
-            .mavlink
-            .request_servo_output_raw()
-            .await
-            .context("Failed waiting for SERVO_OUTPUT_RAW_DATA message")?;
-
-        let state = actuators_state_from_servo(actuators, &servo_output_raw);
-        actuators.state = state;
-        crate::actuators_watch::mark_servo_from_get_state(*camera_uuid);
-
-        Ok(actuators.state)
-    }
-
-    #[allow(dead_code)] // Convenience when the caller already holds MANAGER.write().
-    #[instrument(level = "debug", skip(self))]
-    pub async fn update_state(
-        &mut self,
-        camera_uuid: &Uuid,
-        new_state: &api::ActuatorsState,
-    ) -> Result<api::ActuatorsState> {
-        let focus_was_set = new_state.focus.is_some();
-        self.apply_state_setpoints(camera_uuid, new_state).await?;
-
-        // Prefer measured SERVO positions so the WS stream does not treat the
-        // requested setpoint as authoritative when the autopilot never moved.
-        match self.get_state(camera_uuid).await {
-            Ok(measured) => {
-                if focus_was_set {
-                    self.check_focus_script_health(camera_uuid).await;
-                }
-                Ok(measured)
-            }
-            Err(error) => {
-                if focus_was_set {
-                    self.check_focus_script_health(camera_uuid).await;
-                }
-                // Do not fall back to the unverified setpoint — that lied to the UI.
-                Err(error)
-            }
-        }
-    }
-
     /// Send focus/zoom setpoints without waiting for SERVO (caller measures separately).
     ///
     /// Only needs `&self` so callers can send MAVLink commands without holding

--- a/backend/libs/autopilot/src/manager/mod.rs
+++ b/backend/libs/autopilot/src/manager/mod.rs
@@ -80,22 +80,10 @@ impl State {
 impl Manager {
     /// Send focus/zoom setpoints without waiting for SERVO (caller measures separately).
     ///
-    /// Only needs `&self` so callers can send MAVLink commands without holding
-    /// `MANAGER.write()` across ACK retries.
-    #[instrument(level = "debug", skip(self))]
-    pub async fn apply_state_setpoints(
-        &self,
-        _camera_uuid: &Uuid,
-        new_state: &api::ActuatorsState,
-    ) -> Result<()> {
+    /// Does not touch `MANAGER` — caller must validate the camera has actuators first.
+    #[instrument(level = "debug")]
+    pub async fn apply_state_setpoints(new_state: &api::ActuatorsState) -> Result<()> {
         use ::mavlink::ardupilotmega::{COMMAND_LONG_DATA, CameraZoomType, MavCmd, SetFocusType};
-
-        // Ensure the camera has an actuators entry before we send commands.
-        let _ = self
-            .settings
-            .actuators
-            .get(_camera_uuid)
-            .context(crate::ACTUATORS_NOT_CONFIGURED)?;
 
         if new_state.tilt.is_some() {
             if new_state.focus.is_none() && new_state.zoom.is_none() {
@@ -105,8 +93,10 @@ impl Manager {
             warn!("Ignoring unimplemented tilt setpoint; applying focus/zoom only");
         }
 
+        let mavlink = crate::mavlink::component()?;
+
         if let Some(focus) = new_state.focus {
-            crate::mavlink::component()?
+            mavlink
                 .send_command(COMMAND_LONG_DATA {
                     target_system: 1,
                     target_component: 1,
@@ -122,7 +112,7 @@ impl Manager {
         }
 
         if let Some(zoom) = new_state.zoom {
-            crate::mavlink::component()?
+            mavlink
                 .send_command(COMMAND_LONG_DATA {
                     target_system: 1,
                     target_component: 1,

--- a/backend/libs/autopilot/src/manager/mod.rs
+++ b/backend/libs/autopilot/src/manager/mod.rs
@@ -6,9 +6,9 @@ mod script;
 mod tilt;
 mod zoom;
 
+use ::mavlink::ardupilotmega::SERVO_OUTPUT_RAW_DATA;
 use anyhow::{Context, Result};
 use indexmap::IndexMap;
-use mavlink::ardupilotmega::SERVO_OUTPUT_RAW_DATA;
 use once_cell::sync::OnceCell;
 use tokio::sync::RwLock;
 use tracing::*;
@@ -20,14 +20,13 @@ use settings::MANAGER as SETTINGS_MANAGER;
 use crate::{
     CameraActuators,
     api::{self, ServoChannel},
-    mavlink::MavlinkComponent,
+    mavlink::{self, MavlinkComponent},
 };
 
 pub static MANAGER: OnceCell<RwLock<Manager>> = OnceCell::new();
 
 #[derive(Debug)]
 pub struct Manager {
-    pub mavlink: MavlinkComponent,
     pub autopilot_scripts_file: String,
     pub settings: State,
     pub(crate) script_health: ScriptHealthTracker,
@@ -107,7 +106,7 @@ impl Manager {
         }
 
         if let Some(focus) = new_state.focus {
-            self.mavlink
+            crate::mavlink::component()?
                 .send_command(COMMAND_LONG_DATA {
                     target_system: 1,
                     target_component: 1,
@@ -123,7 +122,7 @@ impl Manager {
         }
 
         if let Some(zoom) = new_state.zoom {
-            self.mavlink
+            crate::mavlink::component()?
                 .send_command(COMMAND_LONG_DATA {
                     target_system: 1,
                     target_component: 1,
@@ -189,14 +188,18 @@ impl Manager {
 
         reload_script |= self.export_script(camera_uuid, overwrite).await?;
 
-        autopilot_reboot_required |= self.mavlink.enable_lua_script(overwrite).await?;
+        autopilot_reboot_required |= crate::mavlink::component()?
+            .enable_lua_script(overwrite)
+            .await?;
 
         if reload_script && !autopilot_reboot_required {
-            self.mavlink.reload_lua_scripts(overwrite).await?;
+            crate::mavlink::component()?
+                .reload_lua_scripts(overwrite)
+                .await?;
         }
 
         if autopilot_reboot_required {
-            self.mavlink.reboot_autopilot().await?;
+            crate::mavlink::component()?.reboot_autopilot().await?;
         }
 
         // Re-push ENABLE/GAIN only when the Lua script was rewritten/reloaded (or a
@@ -246,12 +249,12 @@ pub async fn init(
 
     let mavlink =
         MavlinkComponent::try_new(mavlink_address, mavlink_system_id, mavlink_component_id).await?;
+    mavlink::init_component(mavlink)?;
 
     let script_health = ScriptHealthTracker::default();
 
     MANAGER.get_or_init(|| {
         RwLock::new(Manager {
-            mavlink,
             autopilot_scripts_file,
             settings,
             script_health,

--- a/backend/libs/autopilot/src/manager/script.rs
+++ b/backend/libs/autopilot/src/manager/script.rs
@@ -73,12 +73,15 @@ impl Manager {
             }
         }
 
-        let autopilot_reboot_required = self.mavlink.enable_lua_script(true).await?;
+        let autopilot_reboot_required =
+            crate::mavlink::component()?.enable_lua_script(true).await?;
 
         if !autopilot_reboot_required {
-            self.mavlink.reload_lua_scripts(true).await?;
+            crate::mavlink::component()?
+                .reload_lua_scripts(true)
+                .await?;
         } else {
-            self.mavlink.reboot_autopilot().await?;
+            crate::mavlink::component()?.reboot_autopilot().await?;
         }
 
         Ok(())
@@ -100,14 +103,16 @@ impl Manager {
                 .entry(*camera_uuid)
                 .or_default()
                 .parameters;
-            let encoding = self.mavlink.encoding().await;
+            let encoding = crate::mavlink::component()?.encoding().await;
 
             // Disables the old script_channel:
             if &current_parameters.script_channel != channel {
                 let param_name =
                     format!("SERVO{}_FUNCTION", current_parameters.script_channel as u8);
 
-                let mut param = self.mavlink.get_param(&param_name, false).await?;
+                let mut param = crate::mavlink::component()?
+                    .get_param(&param_name, false)
+                    .await?;
                 let old_value = param.value;
                 param
                     .value
@@ -115,7 +120,7 @@ impl Manager {
                 let new_value = param.value;
 
                 if old_value != new_value {
-                    match self.mavlink.set_param(param).await {
+                    match crate::mavlink::component()?.set_param(param).await {
                         Ok(_) => {
                             if old_value != new_value {
                                 info!(
@@ -141,7 +146,9 @@ impl Manager {
                 // The script servo input is the values from the CameraFocus
                 let function = ChannelFunction::CameraFocus;
 
-                let mut param = self.mavlink.get_param(&param_name, false).await?;
+                let mut param = crate::mavlink::component()?
+                    .get_param(&param_name, false)
+                    .await?;
                 let old_value = param.value;
                 param
                     .value
@@ -149,7 +156,7 @@ impl Manager {
                 let new_value = param.value;
 
                 if overwrite || old_value != new_value {
-                    match self.mavlink.set_param(param).await {
+                    match crate::mavlink::component()?.set_param(param).await {
                         Ok(_) => {
                             if overwrite || old_value != new_value {
                                 info!(
@@ -206,13 +213,15 @@ impl Manager {
             return Ok(());
         }
 
-        let encoding = self.mavlink.encoding().await;
-        let mut param = self.mavlink.get_param(&param_name, false).await?;
+        let encoding = crate::mavlink::component()?.encoding().await;
+        let mut param = crate::mavlink::component()?
+            .get_param(&param_name, false)
+            .await?;
         param
             .value
             .set_value(ParamType::UINT8(new_value as u8), encoding)?;
 
-        match self.mavlink.set_param(param).await {
+        match crate::mavlink::component()?.set_param(param).await {
             Ok(_) => {
                 if old_value != new_value {
                     info!(
@@ -259,13 +268,15 @@ impl Manager {
             return Ok(());
         }
 
-        let encoding = self.mavlink.encoding().await;
-        let mut param = self.mavlink.get_param(&param_name, false).await?;
+        let encoding = crate::mavlink::component()?.encoding().await;
+        let mut param = crate::mavlink::component()?
+            .get_param(&param_name, false)
+            .await?;
         param
             .value
             .set_value(ParamType::UINT8(new_value as u8), encoding)?;
 
-        match self.mavlink.set_param(param).await {
+        match crate::mavlink::component()?.set_param(param).await {
             Ok(_) => {
                 if old_value != new_value {
                     info!(

--- a/backend/libs/autopilot/src/manager/script.rs
+++ b/backend/libs/autopilot/src/manager/script.rs
@@ -327,37 +327,18 @@ impl Manager {
         script_channel
     );
 
-    /// Fetch a SERVO sample then evaluate script health.
-    ///
-    /// Callers that already hold `MANAGER.write()` must not use this — wait for
-    /// SERVO under a read lock and call [`Self::apply_focus_script_health_sample`].
-    pub async fn check_focus_script_health(&mut self, camera_uuid: &Uuid) {
-        let Some(actuators) = self.settings.actuators.get(camera_uuid) else {
-            return;
-        };
-
-        if !actuators.parameters.enable_focus_and_zoom_correlation {
-            return;
-        }
-
-        let servo_output_raw = match self.mavlink.request_servo_output_raw().await {
-            Ok(data) => data,
-            Err(_) => return,
-        };
-
-        self.apply_focus_script_health_sample(camera_uuid, &servo_output_raw)
-            .await;
-    }
-
     /// Evaluate focus-script health from an already-fetched SERVO sample.
-    pub async fn apply_focus_script_health_sample(
+    ///
+    /// Returns `true` when a Lua reload should be attempted. Callers must invoke
+    /// `reload_lua_scripts` **without** holding `MANAGER.write()`.
+    pub fn apply_focus_script_health_sample(
         &mut self,
         camera_uuid: &Uuid,
         servo_output_raw: &SERVO_OUTPUT_RAW_DATA,
-    ) {
+    ) -> bool {
         let (script_channel, focus_channel, enabled) = {
             let Some(actuators) = self.settings.actuators.get(camera_uuid) else {
-                return;
+                return false;
             };
             (
                 actuators.parameters.script_channel,
@@ -367,7 +348,7 @@ impl Manager {
         };
 
         if !enabled {
-            return;
+            return false;
         }
 
         // script_channel (e.g. SERVO12) = CameraFocus = input to the Lua script
@@ -375,14 +356,10 @@ impl Manager {
         // focus_channel (e.g. SERVO10) = Script1 = output from the Lua script
         let script_output_raw = get_output_raw_from_channel(servo_output_raw, focus_channel);
 
-        if let (Some(input_raw), Some(output_raw)) = (script_input_raw, script_output_raw)
-            && self.script_health.update(input_raw, output_raw)
-        {
-            warn!("Attempting Lua script reload due to stale focus output");
-            if let Err(error) = self.mavlink.reload_lua_scripts(true).await {
-                error!("Failed to reload Lua scripts: {error:?}");
-            }
+        if let (Some(input_raw), Some(output_raw)) = (script_input_raw, script_output_raw) {
+            return self.script_health.update(input_raw, output_raw);
         }
+        false
     }
 }
 

--- a/backend/libs/autopilot/src/manager/tilt.rs
+++ b/backend/libs/autopilot/src/manager/tilt.rs
@@ -26,13 +26,15 @@ impl Manager {
                 .entry(*camera_uuid)
                 .or_default()
                 .parameters;
-            let encoding = self.mavlink.encoding().await;
+            let encoding = crate::mavlink::component()?.encoding().await;
 
             // Disables the old tilt_channel:
             if &current_parameters.tilt_channel != channel {
                 let param_name = format!("SERVO{}_FUNCTION", current_parameters.tilt_channel as u8);
 
-                let mut param = self.mavlink.get_param(&param_name, false).await?;
+                let mut param = crate::mavlink::component()?
+                    .get_param(&param_name, false)
+                    .await?;
                 let old_value = param.value;
                 param
                     .value
@@ -40,7 +42,7 @@ impl Manager {
                 let new_value = param.value;
 
                 if old_value != new_value {
-                    match self.mavlink.set_param(param).await {
+                    match crate::mavlink::component()?.set_param(param).await {
                         Ok(_) => {
                             if old_value != new_value {
                                 info!(
@@ -68,7 +70,9 @@ impl Manager {
                     api::CameraID::CAM2 => ChannelFunction::Mount2Pitch,
                 };
 
-                let mut param = self.mavlink.get_param(&param_name, false).await?;
+                let mut param = crate::mavlink::component()?
+                    .get_param(&param_name, false)
+                    .await?;
                 let old_value = param.value;
                 param
                     .value
@@ -76,7 +80,7 @@ impl Manager {
                 let new_value = param.value;
 
                 if overwrite || old_value != new_value {
-                    match self.mavlink.set_param(param).await {
+                    match crate::mavlink::component()?.set_param(param).await {
                         Ok(_) => {
                             if overwrite || old_value != new_value {
                                 info!(
@@ -182,7 +186,7 @@ impl Manager {
             .or_default()
             .parameters;
 
-        let encoding = self.mavlink.encoding().await;
+        let encoding = crate::mavlink::component()?.encoding().await;
 
         // Debug name is MNT1/MNT2 (same as pitch macros), not the SERVO function u8.
         let mount_id = match current_parameters.camera_id {
@@ -196,14 +200,16 @@ impl Manager {
             (None, true) => current_parameters.tilt_mnt_type,
             (None, false) => return Ok(()),
         };
-        let mut param = self.mavlink.get_param(&param_name, false).await?;
+        let mut param = crate::mavlink::component()?
+            .get_param(&param_name, false)
+            .await?;
         let old_value_encoded = param.param_value(encoding)?;
         param
             .value
             .set_value(ParamType::INT32(new_value as i32), encoding)?;
         let new_value_encoded = param.param_value(encoding)?;
         if (old_value_encoded != new_value_encoded) || force_apply {
-            match self.mavlink.set_param(param).await {
+            match crate::mavlink::component()?.set_param(param).await {
                 Ok(_) => {
                     if old_value_encoded != new_value_encoded {
                         info!(

--- a/backend/libs/autopilot/src/manager/zoom.rs
+++ b/backend/libs/autopilot/src/manager/zoom.rs
@@ -110,8 +110,7 @@ impl Manager {
         parameters: &api::ActuatorsParametersConfig,
         force_apply: bool,
     ) -> Result<()> {
-        (self)
-            .update_zoom_channel_min(camera_uuid, parameters, force_apply)
+        self.update_zoom_channel_min(camera_uuid, parameters, force_apply)
             .await?;
         self.update_zoom_channel_trim(camera_uuid, parameters, force_apply)
             .await?;

--- a/backend/libs/autopilot/src/manager/zoom.rs
+++ b/backend/libs/autopilot/src/manager/zoom.rs
@@ -25,13 +25,15 @@ impl Manager {
                 .entry(*camera_uuid)
                 .or_default()
                 .parameters;
-            let encoding = self.mavlink.encoding().await;
+            let encoding = crate::mavlink::component()?.encoding().await;
 
             // Disables the old zoom_channel:
             if &current_parameters.zoom_channel != channel {
                 let param_name = format!("SERVO{}_FUNCTION", current_parameters.zoom_channel as u8);
 
-                let mut param = self.mavlink.get_param(&param_name, false).await?;
+                let mut param = crate::mavlink::component()?
+                    .get_param(&param_name, false)
+                    .await?;
                 let old_value = param.value;
                 param
                     .value
@@ -39,7 +41,7 @@ impl Manager {
                 let new_value = param.value;
 
                 if old_value != new_value {
-                    match self.mavlink.set_param(param).await {
+                    match crate::mavlink::component()?.set_param(param).await {
                         Ok(_) => {
                             if old_value != new_value {
                                 info!(
@@ -62,7 +64,9 @@ impl Manager {
             {
                 let param_name = format!("SERVO{}_FUNCTION", *channel as u8);
 
-                let mut param = self.mavlink.get_param(&param_name, false).await?;
+                let mut param = crate::mavlink::component()?
+                    .get_param(&param_name, false)
+                    .await?;
                 let old_value = param.value;
                 param.value.set_value(
                     ParamType::INT16(ChannelFunction::CameraZoom as i16),
@@ -71,7 +75,7 @@ impl Manager {
                 let new_value = param.value;
 
                 if overwrite || old_value != new_value {
-                    match self.mavlink.set_param(param).await {
+                    match crate::mavlink::component()?.set_param(param).await {
                         Ok(_) => {
                             if overwrite || old_value != new_value {
                                 info!(

--- a/backend/libs/autopilot/src/mavlink/mod.rs
+++ b/backend/libs/autopilot/src/mavlink/mod.rs
@@ -226,7 +226,16 @@ impl MavlinkComponent {
         self.wait_autopilot().await?;
 
         Self::configure_parameter_encoding(self.inner.clone()).await;
-        Self::update_all_params(self.inner.clone()).await;
+        // Bound so a wedged autopilot cannot stall reboot forever.
+        if tokio::time::timeout(
+            tokio::time::Duration::from_secs(60),
+            Self::update_all_params(self.inner.clone()),
+        )
+        .await
+        .is_err()
+        {
+            warn!("Timed out refreshing parameters after autopilot reboot");
+        }
 
         Ok(())
     }
@@ -238,7 +247,7 @@ impl MavlinkComponent {
         let target_component = mavlink::ardupilotmega::MavComponent::MAV_COMP_ID_AUTOPILOT1 as u8;
         let mut receiver = self.inner.get_receiver().await;
 
-        let wait_command_ack = async {
+        let wait_heartbeat = async {
             loop {
                 use broadcast::error::RecvError;
 
@@ -246,7 +255,7 @@ impl MavlinkComponent {
                     Ok(Message::Received((recv_header, recv_message)))
                         if recv_header.system_id == target_system
                             && recv_header.component_id == target_component
-                            && matches!(recv_message, MavMessage::COMMAND_ACK(_)) =>
+                            && matches!(recv_message, MavMessage::HEARTBEAT(_)) =>
                     {
                         if let MavMessage::HEARTBEAT(heartbeat) = recv_message {
                             use mavlink::ardupilotmega::MavState;
@@ -275,15 +284,15 @@ impl MavlinkComponent {
             }
         };
 
-        match tokio::time::timeout(tokio::time::Duration::from_secs(15), wait_command_ack).await {
-            Ok(res) => return res,
+        match tokio::time::timeout(tokio::time::Duration::from_secs(15), wait_heartbeat).await {
+            Ok(res) => res,
             Err(_) => {
-                warn!("Timeout waiting for autopilot {target_system}:{target_component}, retrying");
-                tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+                warn!(
+                    "Timeout waiting for autopilot {target_system}:{target_component} heartbeat; continuing"
+                );
+                Ok(())
             }
         }
-
-        Ok(())
     }
 
     #[instrument(level = "debug", skip(self))]

--- a/backend/libs/autopilot/src/mavlink/mod.rs
+++ b/backend/libs/autopilot/src/mavlink/mod.rs
@@ -264,7 +264,14 @@ impl MavlinkComponent {
     }
 
     #[instrument(level = "debug", skip(self))]
-    pub async fn send_command(&self, mut command: COMMAND_LONG_DATA) -> Result<()> {
+    pub async fn send_command(&self, command: COMMAND_LONG_DATA) -> Result<()> {
+        let _txn = self.inner.txn.lock().await;
+        self.send_command_locked(command).await
+    }
+
+    /// Send a command and wait for ACK. Caller must hold [`ComponentInner::txn`].
+    #[instrument(level = "debug", skip(self))]
+    async fn send_command_locked(&self, mut command: COMMAND_LONG_DATA) -> Result<()> {
         let target_system = self.inner.system_id;
         let target_component = mavlink::ardupilotmega::MavComponent::MAV_COMP_ID_AUTOPILOT1 as u8;
         let this_system = self.inner.system_id;
@@ -374,17 +381,16 @@ impl MavlinkComponent {
         .await
     }
 
+    /// One-shot request for `SERVO_OUTPUT_RAW`. Holds the mavlink txn for the whole RPC.
     pub async fn request_servo_output_raw(&self) -> Result<SERVO_OUTPUT_RAW_DATA> {
         let target_system = self.inner.system_id;
         let target_component = mavlink::ardupilotmega::MavComponent::MAV_COMP_ID_AUTOPILOT1 as u8;
 
-        let wait_servo_output_raw_handle = tokio::spawn({
-            let inner = self.inner.clone();
+        let _txn = self.inner.txn.lock().await;
+        // Subscribe before send so the first SERVO frame cannot be missed.
+        let mut receiver = self.inner.get_receiver().await;
 
-            Self::wait_servo_output_raw(inner)
-        });
-
-        self.send_command(COMMAND_LONG_DATA {
+        self.send_command_locked(COMMAND_LONG_DATA {
             command: MavCmd::MAV_CMD_REQUEST_MESSAGE,
             target_system,
             target_component,
@@ -394,16 +400,14 @@ impl MavlinkComponent {
         })
         .await?;
 
-        wait_servo_output_raw_handle.await?
+        Self::wait_servo_output_raw_on(&mut receiver, target_system, target_component).await
     }
 
-    pub async fn wait_servo_output_raw(
-        inner: Arc<ComponentInner>,
+    async fn wait_servo_output_raw_on(
+        receiver: &mut broadcast::Receiver<Message>,
+        target_system: u8,
+        target_component: u8,
     ) -> Result<SERVO_OUTPUT_RAW_DATA> {
-        let target_system = inner.system_id;
-        let target_component = mavlink::ardupilotmega::MavComponent::MAV_COMP_ID_AUTOPILOT1 as u8;
-        let mut receiver = inner.get_receiver().await;
-
         let wait_message = async {
             loop {
                 use broadcast::error::RecvError;
@@ -455,6 +459,9 @@ pub(crate) struct ComponentInner {
     pub component_id: u8,
     pub encoding: Arc<RwLock<ParamEncodingType>>,
     pub parameters: Arc<RwLock<IndexMap<String, Parameter>>>,
+    /// Serializes correlated MAVLink RPCs (command ACK / PARAM_VALUE matching).
+    /// Lock order: never acquire MANAGER while holding this.
+    pub txn: tokio::sync::Mutex<()>,
     connection: Connection,
 }
 
@@ -520,6 +527,7 @@ impl ComponentInner {
             component_id,
             encoding: Arc::new(RwLock::new(ParamEncodingType::default())),
             parameters: Arc::new(RwLock::new(IndexMap::with_capacity(2048))),
+            txn: tokio::sync::Mutex::new(()),
             connection,
         })
     }

--- a/backend/libs/autopilot/src/mavlink/mod.rs
+++ b/backend/libs/autopilot/src/mavlink/mod.rs
@@ -11,6 +11,7 @@ use mavlink::{
     self, MavHeader, Message as _, MessageData,
     ardupilotmega::{COMMAND_LONG_DATA, MavCmd, MavMessage, MavResult, SERVO_OUTPUT_RAW_DATA},
 };
+use once_cell::sync::OnceCell;
 use tokio::sync::{RwLock, broadcast};
 use tracing::*;
 
@@ -18,6 +19,24 @@ use crate::{
     mavlink::{connection::Connection, parameters::ParamEncodingType},
     parameters::{ParamType, Parameter},
 };
+
+/// Process-lifetime owner of MAVLink tasks. Never dropped while the process runs
+/// (soft restart keeps the existing connection string).
+static MAVLINK_COMPONENT: OnceCell<MavlinkComponent> = OnceCell::new();
+
+/// Shared MAVLink API. Independent of [`crate::manager::MANAGER`] so I/O need not
+/// hold the settings lock.
+pub fn component() -> Result<&'static MavlinkComponent> {
+    MAVLINK_COMPONENT
+        .get()
+        .context("MAVLink component not initialized")
+}
+
+pub(crate) fn init_component(component: MavlinkComponent) -> Result<()> {
+    MAVLINK_COMPONENT
+        .set(component)
+        .map_err(|_| anyhow!("MAVLink component already initialized"))
+}
 
 #[derive(Debug)]
 pub struct MavlinkComponent {
@@ -29,6 +48,10 @@ pub struct MavlinkComponent {
 }
 
 impl MavlinkComponent {
+    pub fn system_id(&self) -> u8 {
+        self.inner.system_id
+    }
+
     #[instrument(level = "debug")]
     pub async fn try_new(address: String, system_id: u8, component_id: u8) -> Result<Self> {
         let inner = Arc::new(ComponentInner::try_new(address, system_id, component_id).await?);

--- a/backend/libs/autopilot/src/mavlink/parameters.rs
+++ b/backend/libs/autopilot/src/mavlink/parameters.rs
@@ -278,7 +278,13 @@ impl MavlinkComponent {
 
     #[instrument(level = "debug", skip(self))]
     pub async fn get_param(&self, param_name: &str, skip_cache: bool) -> Result<Parameter> {
-        Self::get_param_inner(self.inner.clone(), param_name, skip_cache).await
+        if !skip_cache && let Some(parameter) = self.inner.parameters.read().await.get(param_name) {
+            trace!("Got parameter from cache!");
+            return Ok(parameter.clone());
+        }
+
+        let _txn = self.inner.txn.lock().await;
+        Self::get_param_inner(self.inner.clone(), param_name, true).await
     }
 
     #[instrument(level = "debug", skip(inner))]
@@ -404,6 +410,7 @@ impl MavlinkComponent {
 
     #[instrument(level = "debug", skip(self))]
     pub async fn set_param(&self, parameter: Parameter) -> Result<Parameter> {
+        let _txn = self.inner.txn.lock().await;
         Self::set_param_inner(self.inner.clone(), parameter).await
     }
 

--- a/backend/libs/autopilot/src/mod.rs
+++ b/backend/libs/autopilot/src/mod.rs
@@ -73,12 +73,16 @@ pub(crate) async fn control_inner(
                 .await?;
 
             if reload_script {
-                manager.mavlink.reload_lua_scripts(true).await?;
+                crate::mavlink::component()?
+                    .reload_lua_scripts(true)
+                    .await?;
             }
 
-            let autopilot_reboot_required = manager.mavlink.enable_lua_script(false).await?;
+            let autopilot_reboot_required = crate::mavlink::component()?
+                .enable_lua_script(false)
+                .await?;
             if autopilot_reboot_required {
-                manager.mavlink.reboot_autopilot().await?;
+                crate::mavlink::component()?.reboot_autopilot().await?;
             }
 
             serde_json::to_value({})?
@@ -110,14 +114,10 @@ pub(crate) async fn control_inner(
                         .context(crate::ACTUATORS_NOT_CONFIGURED)?;
                 }
                 let age_before = actuators_watch::last_servo_age(actuators_control.camera_uuid);
-                let servo_output_raw = {
-                    let manager = MANAGER.get().context("Not available")?.read().await;
-                    manager
-                        .mavlink
-                        .request_servo_output_raw()
-                        .await
-                        .context("Failed waiting for SERVO_OUTPUT_RAW_DATA message")?
-                };
+                let servo_output_raw = crate::mavlink::component()?
+                    .request_servo_output_raw()
+                    .await
+                    .context("Failed waiting for SERVO_OUTPUT_RAW_DATA message")?;
                 let mut manager = MANAGER.get().context("Not available")?.write().await;
                 let actuators = manager
                     .settings
@@ -147,14 +147,10 @@ pub(crate) async fn control_inner(
                     .await?;
             }
             let age_before = actuators_watch::last_servo_age(camera_uuid);
-            let servo_output_raw = {
-                let manager = MANAGER.get().context("Not available")?.read().await;
-                manager
-                    .mavlink
-                    .request_servo_output_raw()
-                    .await
-                    .context("Failed waiting for SERVO_OUTPUT_RAW_DATA message")?
-            };
+            let servo_output_raw = crate::mavlink::component()?
+                .request_servo_output_raw()
+                .await
+                .context("Failed waiting for SERVO_OUTPUT_RAW_DATA message")?;
             let state = {
                 let mut manager = MANAGER.get().context("Not available")?.write().await;
                 let actuators = manager
@@ -183,10 +179,10 @@ pub(crate) async fn control_inner(
                         .is_some_and(|a| a.parameters.enable_focus_and_zoom_correlation)
                 };
                 if enabled {
-                    let health_servo = {
-                        let manager = MANAGER.get().context("Not available")?.read().await;
-                        manager.mavlink.request_servo_output_raw().await.ok()
-                    };
+                    let health_servo = crate::mavlink::component()?
+                        .request_servo_output_raw()
+                        .await
+                        .ok();
                     if let Some(health_servo) = health_servo {
                         let needs_reload = {
                             let mut manager = MANAGER.get().context("Not available")?.write().await;
@@ -194,8 +190,9 @@ pub(crate) async fn control_inner(
                         };
                         if needs_reload {
                             warn!("Attempting Lua script reload due to stale focus output");
-                            let manager = MANAGER.get().context("Not available")?.read().await;
-                            if let Err(error) = manager.mavlink.reload_lua_scripts(true).await {
+                            if let Err(error) =
+                                crate::mavlink::component()?.reload_lua_scripts(true).await
+                            {
                                 error!("Failed to reload Lua scripts: {error:?}");
                             }
                         }

--- a/backend/libs/autopilot/src/mod.rs
+++ b/backend/libs/autopilot/src/mod.rs
@@ -139,13 +139,16 @@ pub(crate) async fn control_inner(
         Action::SetActuatorsState(new_state) => {
             let camera_uuid = actuators_control.camera_uuid;
             let focus_was_set = new_state.focus.is_some();
-            // Send MAVLink without write lock (ACK retries must not block the watcher).
+            // Validate entry, then send MAVLink with no Manager lock held.
             {
                 let manager = MANAGER.get().context("Not available")?.read().await;
-                manager
-                    .apply_state_setpoints(&camera_uuid, new_state)
-                    .await?;
+                let _ = manager
+                    .settings
+                    .actuators
+                    .get(&camera_uuid)
+                    .context(crate::ACTUATORS_NOT_CONFIGURED)?;
             }
+            manager::Manager::apply_state_setpoints(new_state).await?;
             let age_before = actuators_watch::last_servo_age(camera_uuid);
             let servo_output_raw = crate::mavlink::component()?
                 .request_servo_output_raw()

--- a/backend/libs/autopilot/src/mod.rs
+++ b/backend/libs/autopilot/src/mod.rs
@@ -66,11 +66,13 @@ pub(crate) async fn control_inner(
 
     let res = match &actuators_control.action {
         Action::ExportLuaScript => {
-            let mut manager = MANAGER.get().context("Not available")?.write().await;
-
-            let reload_script = manager
-                .export_script(&actuators_control.camera_uuid, true)
-                .await?;
+            let _apply = manager::CONFIG_APPLY.lock().await;
+            let reload_script = {
+                let mut manager = MANAGER.get().context("Not available")?.write().await;
+                manager
+                    .export_script(&actuators_control.camera_uuid, true)
+                    .await?
+            };
 
             if reload_script {
                 crate::mavlink::component()?
@@ -222,6 +224,7 @@ pub(crate) async fn control_inner(
             serde_json::to_value(config)?
         }
         Action::SetActuatorsConfig(new_config) => {
+            let _apply = manager::CONFIG_APPLY.lock().await;
             let mut manager = MANAGER.get().context("Not available")?.write().await;
             let mut new_config = new_config.to_owned();
 
@@ -235,6 +238,9 @@ pub(crate) async fn control_inner(
             new_config = merge_struct::merge(base_config, &new_config.clone())
                 .context("Failing to merge structs")?;
 
+            // ponytail: still holds MANAGER.write across param I/O — CONFIG_APPLY
+            // serializes mutators; full snapshot-I/O-commit of hand-written channel
+            // swaps is the upgrade path.
             manager
                 .update_config(&actuators_control.camera_uuid, &new_config, false)
                 .await?;
@@ -249,6 +255,7 @@ pub(crate) async fn control_inner(
             serde_json::to_value(config)?
         }
         Action::ResetActuatorsConfig => {
+            let _apply = manager::CONFIG_APPLY.lock().await;
             let mut manager = MANAGER.get().context("Not available")?.write().await;
 
             manager.reset_config(&actuators_control.camera_uuid).await?;

--- a/backend/libs/autopilot/src/mod.rs
+++ b/backend/libs/autopilot/src/mod.rs
@@ -188,10 +188,17 @@ pub(crate) async fn control_inner(
                         manager.mavlink.request_servo_output_raw().await.ok()
                     };
                     if let Some(health_servo) = health_servo {
-                        let mut manager = MANAGER.get().context("Not available")?.write().await;
-                        manager
-                            .apply_focus_script_health_sample(&camera_uuid, &health_servo)
-                            .await;
+                        let needs_reload = {
+                            let mut manager = MANAGER.get().context("Not available")?.write().await;
+                            manager.apply_focus_script_health_sample(&camera_uuid, &health_servo)
+                        };
+                        if needs_reload {
+                            warn!("Attempting Lua script reload due to stale focus output");
+                            let manager = MANAGER.get().context("Not available")?.read().await;
+                            if let Err(error) = manager.mavlink.reload_lua_scripts(true).await {
+                                error!("Failed to reload Lua scripts: {error:?}");
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
Split from the websockets work: **MAVLink txn mutex and slim static MANAGER**.

Commits in this slice:
- `backend: libs: autopilot: manager: Remove dead state helpers and unlock Lua reload`
- `backend: libs: autopilot: mavlink: Add txn mutex and fix SERVO request ordering`
- `backend: libs: autopilot: Own MavlinkComponent statically and slim MANAGER`
- `backend: libs: autopilot: Drop Manager lock around actuator setpoints`
- `backend: libs: autopilot: Serialize config apply and bound reboot param sync`

## Stack
- Part **17/24** of the websockets split (all PRs target `master`)
- Depends on https://github.com/bluerobotics/radcam-manager/pull/217 merging first.
- After the previous stack PR merges: rebase this branch onto `master` and `git push --force-with-lease`
- Intermediate slices may show **red CI** (incomplete stack / missing later fixes). That is expected.
- The batch is only done when tip **[#225](https://github.com/bluerobotics/radcam-manager/pull/225)** (`24/24`) is green after the full merge-rebase dance.

## Test plan
- [ ] MAVLink param/command transactions do not interleave (txn mutex)
- [ ] `MavlinkComponent` lives outside the fat `MANAGER` write lock path for hot operations
- [ ] Actuator setpoints no longer require holding `MANAGER` across the full await
