### PR TITLE
websockets 18/24: Unlock config apply I/O and fix apply lifecycle

### DIFF
--- a/backend/libs/autopilot/src/actuators_watch.rs
+++ b/backend/libs/autopilot/src/actuators_watch.rs
@@ -504,7 +504,7 @@ mod tests {
         };
 
         gate.try_emit(camera_uuid, state, &sender);
-        assert!(gate.last_emitted.get(&camera_uuid).is_none());
+        assert!(!gate.last_emitted.contains_key(&camera_uuid));
         assert!(gate.pending.contains_key(&camera_uuid));
     }
 

--- a/backend/libs/autopilot/src/manager/calibration.rs
+++ b/backend/libs/autopilot/src/manager/calibration.rs
@@ -5,32 +5,23 @@ use uuid::Uuid;
 use crate::{api, manager::Manager};
 
 impl Manager {
-    #[instrument(level = "debug", skip(self, _points))]
-
+    #[instrument(level = "debug", skip(_points))]
     pub async fn update_closest_points(
-        &mut self,
-        camera_uuid: &Uuid,
+        _camera_uuid: &Uuid,
         _points: &api::FocusZoomPoints,
-        overwrite: bool,
+        _overwrite: bool,
     ) -> Result<bool> {
-        let should_update_script = false;
-
         warn!("Skipping: unimplemented");
-
-        Ok(should_update_script)
+        Ok(false)
     }
 
-    #[instrument(level = "debug", skip(self, _points))]
+    #[instrument(level = "debug", skip(_points))]
     pub async fn update_furthest_points(
-        &mut self,
-        camera_uuid: &Uuid,
+        _camera_uuid: &Uuid,
         _points: &api::FocusZoomPoints,
-        overwrite: bool,
+        _overwrite: bool,
     ) -> Result<bool> {
-        let should_update_script = false;
-
         warn!("Skipping: unimplemented");
-
-        Ok(should_update_script)
+        Ok(false)
     }
 }

--- a/backend/libs/autopilot/src/manager/camera.rs
+++ b/backend/libs/autopilot/src/manager/camera.rs
@@ -9,9 +9,8 @@ use crate::{
 };
 
 impl Manager {
-    #[instrument(level = "debug", skip(self, parameters))]
+    #[instrument(level = "debug", skip(parameters))]
     pub async fn update_camera_parameters(
-        &mut self,
         camera_uuid: &Uuid,
         parameters: &api::ActuatorsParametersConfig,
         overwrite: bool,
@@ -19,21 +18,31 @@ impl Manager {
         let mut autopilot_reboot_required = overwrite;
 
         if let Some(camera_id) = &parameters.camera_id {
-            let current_parameters = &mut self
-                .settings
-                .actuators
-                .entry(*camera_uuid)
-                .or_default()
-                .parameters;
-            let encoding = crate::mavlink::component()?.encoding().await;
+            // Snapshot under a short write with no await inside, so the MAVLink I/O
+            // below never runs while MANAGER is locked.
+            let old_camera_id = {
+                let mut manager = crate::manager::MANAGER
+                    .get()
+                    .context("Not available")?
+                    .write()
+                    .await;
+                manager
+                    .settings
+                    .actuators
+                    .entry(*camera_uuid)
+                    .or_default()
+                    .parameters
+                    .camera_id
+            };
+
+            let mavlink = crate::mavlink::component()?;
+            let encoding = mavlink.encoding().await;
 
             // Disables the old camera_id:
-            if &current_parameters.camera_id != camera_id {
-                let param_name = format!("CAM{}_TYPE", current_parameters.camera_id as u8);
+            if &old_camera_id != camera_id {
+                let param_name = format!("CAM{}_TYPE", old_camera_id as u8);
 
-                let mut param = crate::mavlink::component()?
-                    .get_param(&param_name, false)
-                    .await?;
+                let mut param = mavlink.get_param(&param_name, false).await?;
                 let old_value = param.value;
                 param
                     .value
@@ -41,15 +50,13 @@ impl Manager {
                 let new_value = param.value;
 
                 if old_value != new_value {
-                    match crate::mavlink::component()?.set_param(param).await {
+                    match mavlink.set_param(param).await {
                         Ok(_) => {
-                            if old_value != new_value {
-                                info!(
-                                    "camera_id (CAM{}) changed from {:?} to {new_value:?}",
-                                    current_parameters.camera_id as u8, old_value
-                                );
-                                autopilot_reboot_required = true;
-                            }
+                            info!(
+                                "camera_id (CAM{}) changed from {:?} to {new_value:?}",
+                                old_camera_id as u8, old_value
+                            );
+                            autopilot_reboot_required = true;
                         }
                         Err(error) => {
                             return Err(error).context(
@@ -64,9 +71,7 @@ impl Manager {
             {
                 let param_name = format!("CAM{}_TYPE", *camera_id as u8);
 
-                let mut param = crate::mavlink::component()?
-                    .get_param(&param_name, false)
-                    .await?;
+                let mut param = mavlink.get_param(&param_name, false).await?;
                 let old_value = param.value;
                 param
                     .value
@@ -74,16 +79,22 @@ impl Manager {
                 let new_value = param.value;
 
                 if overwrite || old_value != new_value {
-                    match crate::mavlink::component()?.set_param(param).await {
+                    match mavlink.set_param(param).await {
                         Ok(_) => {
-                            if overwrite || old_value != new_value {
-                                info!(
-                                    "camera_id (CAM{}) changed from {:?} to {new_value:?}",
-                                    *camera_id as u8, old_value
-                                );
-                            }
+                            info!(
+                                "camera_id (CAM{}) changed from {:?} to {new_value:?}",
+                                *camera_id as u8, old_value
+                            );
 
-                            current_parameters.camera_id = *camera_id;
+                            let mut manager = crate::manager::MANAGER
+                                .get()
+                                .context("Not available")?
+                                .write()
+                                .await;
+                            if let Some(actuators) = manager.settings.actuators.get_mut(camera_uuid)
+                            {
+                                actuators.parameters.camera_id = *camera_id;
+                            }
                             autopilot_reboot_required = true;
                         }
                         Err(error) => {

--- a/backend/libs/autopilot/src/manager/focus.rs
+++ b/backend/libs/autopilot/src/manager/focus.rs
@@ -9,9 +9,8 @@ use crate::{
 };
 
 impl Manager {
-    #[instrument(level = "debug", skip(self, parameters))]
+    #[instrument(level = "debug", skip(parameters))]
     pub async fn update_focus_parameters(
-        &mut self,
         camera_uuid: &Uuid,
         parameters: &api::ActuatorsParametersConfig,
         overwrite: bool,
@@ -19,22 +18,34 @@ impl Manager {
         let mut autopilot_reboot_required = overwrite;
 
         if let Some(channel) = &parameters.focus_channel {
-            let current_parameters = &mut self
-                .settings
-                .actuators
-                .entry(*camera_uuid)
-                .or_default()
-                .parameters;
-            let encoding = crate::mavlink::component()?.encoding().await;
+            // Snapshot under a short write with no await inside, so the MAVLink I/O
+            // below never runs while MANAGER is locked.
+            let (old_channel, script_function) = {
+                let mut manager = crate::manager::MANAGER
+                    .get()
+                    .context("Not available")?
+                    .write()
+                    .await;
+                let current_parameters = &mut manager
+                    .settings
+                    .actuators
+                    .entry(*camera_uuid)
+                    .or_default()
+                    .parameters;
+                (
+                    current_parameters.focus_channel,
+                    current_parameters.script_function,
+                )
+            };
+
+            let mavlink = crate::mavlink::component()?;
+            let encoding = mavlink.encoding().await;
 
             // Disables the old focus_channel:
-            if &current_parameters.focus_channel != channel {
-                let param_name =
-                    format!("SERVO{}_FUNCTION", current_parameters.focus_channel as u8);
+            if &old_channel != channel {
+                let param_name = format!("SERVO{}_FUNCTION", old_channel as u8);
 
-                let mut param = crate::mavlink::component()?
-                    .get_param(&param_name, false)
-                    .await?;
+                let mut param = mavlink.get_param(&param_name, false).await?;
                 let old_value = param.value;
                 param
                     .value
@@ -42,15 +53,13 @@ impl Manager {
                 let new_value = param.value;
 
                 if old_value != new_value {
-                    match crate::mavlink::component()?.set_param(param).await {
+                    match mavlink.set_param(param).await {
                         Ok(_) => {
-                            if old_value != new_value {
-                                info!(
-                                    "focus_channel (SERVO{}) changed from {:?} to {new_value:?}",
-                                    current_parameters.focus_channel as u8, old_value
-                                );
-                                autopilot_reboot_required = true;
-                            }
+                            info!(
+                                "focus_channel (SERVO{}) changed from {:?} to {new_value:?}",
+                                old_channel as u8, old_value
+                            );
+                            autopilot_reboot_required = true;
                         }
                         Err(error) => {
                             return Err(error).context(
@@ -66,18 +75,15 @@ impl Manager {
                 let param_name = format!("SERVO{}_FUNCTION", *channel as u8);
 
                 // The focus servo input is the script:
-                let function =
-                    ChannelFunction::try_from(current_parameters.script_function as u8 as i16)
-                        .map_err(|error| {
-                            anyhow::anyhow!(
-                                "Invalid script_function {:?} for focus channel: {error:?}",
-                                current_parameters.script_function
-                            )
-                        })?;
+                let function = ChannelFunction::try_from(script_function as u8 as i16).map_err(
+                    |error| {
+                        anyhow::anyhow!(
+                            "Invalid script_function {script_function:?} for focus channel: {error:?}"
+                        )
+                    },
+                )?;
 
-                let mut param = crate::mavlink::component()?
-                    .get_param(&param_name, false)
-                    .await?;
+                let mut param = mavlink.get_param(&param_name, false).await?;
                 let old_value = param.value;
                 param
                     .value
@@ -85,16 +91,22 @@ impl Manager {
                 let new_value = param.value;
 
                 if overwrite || old_value != new_value {
-                    match crate::mavlink::component()?.set_param(param).await {
+                    match mavlink.set_param(param).await {
                         Ok(_) => {
-                            if overwrite || old_value != new_value {
-                                info!(
-                                    "focus_channel (SERVO{}) changed from {:?} to {new_value:?}",
-                                    *channel as u8, old_value
-                                );
-                            }
+                            info!(
+                                "focus_channel (SERVO{}) changed from {:?} to {new_value:?}",
+                                *channel as u8, old_value
+                            );
 
-                            current_parameters.focus_channel = *channel;
+                            let mut manager = crate::manager::MANAGER
+                                .get()
+                                .context("Not available")?
+                                .write()
+                                .await;
+                            if let Some(actuators) = manager.settings.actuators.get_mut(camera_uuid)
+                            {
+                                actuators.parameters.focus_channel = *channel;
+                            }
                             autopilot_reboot_required = true;
                         }
                         Err(error) => {
@@ -107,25 +119,21 @@ impl Manager {
             }
         }
 
-        self.update_focus_channel_parameters(camera_uuid, parameters, autopilot_reboot_required)
+        Self::update_focus_channel_parameters(camera_uuid, parameters, autopilot_reboot_required)
             .await?;
 
         Ok(autopilot_reboot_required)
     }
 
-    #[instrument(level = "debug", skip(self, parameters))]
+    #[instrument(level = "debug", skip(parameters))]
     async fn update_focus_channel_parameters(
-        &mut self,
         camera_uuid: &Uuid,
         parameters: &api::ActuatorsParametersConfig,
         force_apply: bool,
     ) -> Result<()> {
-        self.update_focus_channel_min(camera_uuid, parameters, force_apply)
-            .await?;
-        self.update_focus_channel_trim(camera_uuid, parameters, force_apply)
-            .await?;
-        self.update_focus_channel_max(camera_uuid, parameters, force_apply)
-            .await?;
+        Self::update_focus_channel_min(camera_uuid, parameters, force_apply).await?;
+        Self::update_focus_channel_trim(camera_uuid, parameters, force_apply).await?;
+        Self::update_focus_channel_max(camera_uuid, parameters, force_apply).await?;
 
         Ok(())
     }

--- a/backend/libs/autopilot/src/manager/macros.rs
+++ b/backend/libs/autopilot/src/manager/macros.rs
@@ -8,17 +8,21 @@ macro_rules! generate_update_channel_param_function {
         $ty:ident,
         $channel_field:ident
     ) => {
-        #[instrument(level = "debug", skip(self, parameters))]
+        #[instrument(level = "debug", skip(parameters))]
         async fn $fn_name(
-            &mut self,
             camera_uuid: &Uuid,
             parameters: &$crate::api::ActuatorsParametersConfig,
             force_apply: bool,
         ) -> Result<()> {
-            // Snapshot under &mut self with no await, then release the field borrow
-            // before MAVLink I/O (caller must not hold MANAGER.write across this).
+            // Snapshot under a short write with no await inside, so the MAVLink I/O
+            // below never runs while MANAGER is locked.
             let (param_name, new_value, old_value) = {
-                let current_parameters = &mut self
+                let mut manager = $crate::manager::MANAGER
+                    .get()
+                    .context("Not available")?
+                    .write()
+                    .await;
+                let current_parameters = &mut manager
                     .settings
                     .actuators
                     .entry(*camera_uuid)
@@ -55,7 +59,12 @@ macro_rules! generate_update_channel_param_function {
                             new_value
                         );
                     }
-                    if let Some(actuators) = self.settings.actuators.get_mut(camera_uuid) {
+                    let mut manager = $crate::manager::MANAGER
+                        .get()
+                        .context("Not available")?
+                        .write()
+                        .await;
+                    if let Some(actuators) = manager.settings.actuators.get_mut(camera_uuid) {
                         actuators.parameters.$field_name = new_value;
                     }
                 }
@@ -80,15 +89,19 @@ macro_rules! generate_update_mount_param_function {
         $param_suffix:expr,
         $ty:ident
     ) => {
-        #[instrument(level = "debug", skip(self, parameters))]
+        #[instrument(level = "debug", skip(parameters))]
         pub async fn $fn_name(
-            &mut self,
             camera_uuid: &Uuid,
             parameters: &$crate::api::ActuatorsParametersConfig,
             force_apply: bool,
         ) -> Result<bool> {
             let (param_name, new_value, old_value) = {
-                let current_parameters = &mut self
+                let mut manager = $crate::manager::MANAGER
+                    .get()
+                    .context("Not available")?
+                    .write()
+                    .await;
+                let current_parameters = &mut manager
                     .settings
                     .actuators
                     .entry(*camera_uuid)
@@ -128,7 +141,12 @@ macro_rules! generate_update_mount_param_function {
                             new_value
                         );
                     }
-                    if let Some(actuators) = self.settings.actuators.get_mut(camera_uuid) {
+                    let mut manager = $crate::manager::MANAGER
+                        .get()
+                        .context("Not available")?
+                        .write()
+                        .await;
+                    if let Some(actuators) = manager.settings.actuators.get_mut(camera_uuid) {
                         actuators.parameters.$field_name = new_value;
                     }
                     Ok(old_value != new_value)

--- a/backend/libs/autopilot/src/manager/mod.rs
+++ b/backend/libs/autopilot/src/manager/mod.rs
@@ -29,6 +29,96 @@ pub static MANAGER: OnceCell<RwLock<Manager>> = OnceCell::new();
 /// Lock order: CONFIG_APPLY → MANAGER → mavlink txn.
 pub static CONFIG_APPLY: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
+/// Hold [`CONFIG_APPLY`] for `under_apply`. If it returns `true`, drop the mutex,
+/// run `reboot`, re-acquire, then run `finalize`.
+#[instrument(level = "debug", skip_all)]
+pub async fn reboot_outside_apply_with<U, R, F>(
+    under_apply: U,
+    reboot: R,
+    finalize: F,
+) -> Result<()>
+where
+    U: std::future::Future<Output = Result<bool>>,
+    R: std::future::Future<Output = Result<()>>,
+    F: std::future::Future<Output = Result<()>>,
+{
+    let mut apply = CONFIG_APPLY.lock().await;
+    let needs_reboot = under_apply.await?;
+    if needs_reboot {
+        drop(apply);
+        reboot.await?;
+        apply = CONFIG_APPLY.lock().await;
+        finalize.await?;
+    }
+    drop(apply);
+    Ok(())
+}
+
+/// Hold [`CONFIG_APPLY`] for `under_apply`. If it returns `true`, drop the mutex,
+/// reboot the autopilot, re-acquire, then run `finalize`.
+pub async fn reboot_outside_apply<U, F>(under_apply: U, finalize: F) -> Result<()>
+where
+    U: std::future::Future<Output = Result<bool>>,
+    F: std::future::Future<Output = Result<()>>,
+{
+    reboot_outside_apply_with(
+        under_apply,
+        async { crate::mavlink::component()?.reboot_autopilot().await },
+        finalize,
+    )
+    .await
+}
+
+#[cfg(test)]
+mod apply_tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::reboot_outside_apply_with;
+
+    #[tokio::test]
+    async fn finalize_runs_only_after_reboot_when_needed() {
+        let phase = AtomicUsize::new(0);
+        reboot_outside_apply_with(
+            async {
+                assert_eq!(phase.load(Ordering::SeqCst), 0);
+                phase.store(1, Ordering::SeqCst);
+                Ok(true)
+            },
+            async {
+                assert_eq!(phase.load(Ordering::SeqCst), 1);
+                phase.store(2, Ordering::SeqCst);
+                Ok(())
+            },
+            async {
+                assert_eq!(phase.load(Ordering::SeqCst), 2);
+                phase.store(3, Ordering::SeqCst);
+                Ok(())
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(phase.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn finalize_skipped_when_no_reboot() {
+        let finalized = AtomicUsize::new(0);
+        reboot_outside_apply_with(
+            async { Ok(false) },
+            async {
+                panic!("reboot must not run");
+            },
+            async {
+                finalized.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(finalized.load(Ordering::SeqCst), 0);
+    }
+}
+
 #[derive(Debug)]
 pub struct Manager {
     pub autopilot_scripts_file: String,
@@ -58,26 +148,6 @@ impl State {
             .collect();
 
         Ok(Self { actuators })
-    }
-
-    #[instrument(level = "debug", skip(self))]
-    pub async fn save(&self) -> Result<()> {
-        let actuators = self
-            .actuators
-            .iter()
-            .map(|(uuid, actuator_settings)| (*uuid, actuator_settings.into()))
-            .collect();
-
-        let settings = &mut SETTINGS_MANAGER
-            .get()
-            .context("Not available")?
-            .write()
-            .await
-            .settings;
-
-        *settings.get_actuators_mut() = actuators;
-
-        settings.save().await
     }
 }
 
@@ -289,14 +359,32 @@ pub async fn init(
 
 #[instrument(level = "debug")]
 pub async fn clear_saved_settings() -> Result<()> {
+    let mut apply = CONFIG_APPLY.lock().await;
+
     settings::clear().await?;
 
-    let _apply = CONFIG_APPLY.lock().await;
-    let manager = MANAGER.get().context("Not available")?;
-    let mut guard = manager.write().await;
-    guard.remove_script().await?;
-    guard.script_health = ScriptHealthTracker::default();
-    guard.settings = State::from_settings().await?;
+    let path = {
+        let manager = MANAGER.get().context("Not available")?.read().await;
+        manager.autopilot_scripts_file.clone()
+    };
+
+    Manager::delete_script_file(&path).await?;
+    let needs_reboot = Manager::disable_or_reload_lua().await?;
+
+    if needs_reboot {
+        drop(apply);
+        crate::mavlink::component()?.reboot_autopilot().await?;
+        apply = CONFIG_APPLY.lock().await;
+    }
+
+    // Post-conditions always (reload Done path and post-reboot): never await under write.
+    let settings = State::from_settings().await?;
+    {
+        let mut guard = MANAGER.get().context("Not available")?.write().await;
+        guard.script_health = ScriptHealthTracker::default();
+        guard.settings = settings;
+    }
+    drop(apply);
 
     Ok(())
 }

--- a/backend/libs/autopilot/src/manager/mod.rs
+++ b/backend/libs/autopilot/src/manager/mod.rs
@@ -62,8 +62,6 @@ impl State {
 
     #[instrument(level = "debug", skip(self))]
     pub async fn save(&self) -> Result<()> {
-        // Clone under the caller's MANAGER guard, then drop any implication that
-        // disk I/O needs the actuators map borrow — SETTINGS_MANAGER is separate.
         let actuators = self
             .actuators
             .iter()
@@ -95,7 +93,6 @@ impl Manager {
             if new_state.focus.is_none() && new_state.zoom.is_none() {
                 return Err(anyhow::anyhow!("Tilt setpoint is not implemented"));
             }
-            // Clients that echo a full ActuatorsState still need focus/zoom to apply.
             warn!("Ignoring unimplemented tilt setpoint; applying focus/zoom only");
         }
 
@@ -110,7 +107,7 @@ impl Manager {
                     confirmation: 0,
                     param1: SetFocusType::FOCUS_TYPE_RANGE as u8 as f32,
                     param2: focus,
-                    param3: 0 as f32, // autopilot cameras
+                    param3: 0 as f32,
                     ..Default::default()
                 })
                 .await
@@ -126,7 +123,7 @@ impl Manager {
                     confirmation: 0,
                     param1: CameraZoomType::ZOOM_TYPE_RANGE as u8 as f32,
                     param2: zoom,
-                    param3: 0 as f32, // autopilot cameras
+                    param3: 0 as f32,
                     ..Default::default()
                 })
                 .await
@@ -136,53 +133,70 @@ impl Manager {
         Ok(())
     }
 
-    #[instrument(level = "debug", skip(self))]
+    /// Persist actuators settings without holding `MANAGER.write` across disk I/O.
+    #[instrument(level = "debug")]
+    pub async fn save_actuators_settings() -> Result<()> {
+        let actuators = {
+            let manager = MANAGER.get().context("Not available")?.read().await;
+            manager
+                .settings
+                .actuators
+                .iter()
+                .map(|(uuid, actuator_settings)| (*uuid, actuator_settings.into()))
+                .collect()
+        };
+
+        let settings = &mut SETTINGS_MANAGER
+            .get()
+            .context("Not available")?
+            .write()
+            .await
+            .settings;
+
+        *settings.get_actuators_mut() = actuators;
+        settings.save().await
+    }
+
+    /// Apply config without holding `MANAGER.write` across MAVLink I/O.
+    ///
+    /// Caller must hold [`CONFIG_APPLY`]. Returns `true` if the autopilot must be
+    /// rebooted before [`Self::finalize_config_after_reboot`] (enable/gain + save).
+    #[instrument(level = "debug", skip(new_config))]
     pub async fn update_config(
-        &mut self,
         camera_uuid: &Uuid,
         new_config: &api::ActuatorsConfig,
         overwrite: bool,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         let mut autopilot_reboot_required = overwrite;
 
-        // Parameters update
         if let Some(parameters) = &new_config.parameters {
-            autopilot_reboot_required |= self
-                .update_camera_parameters(camera_uuid, parameters, overwrite)
-                .await?;
+            autopilot_reboot_required |=
+                Self::update_camera_parameters(camera_uuid, parameters, overwrite).await?;
 
-            autopilot_reboot_required |= self
-                .update_script_parameters(camera_uuid, parameters, overwrite)
-                .await?;
+            autopilot_reboot_required |=
+                Self::update_script_parameters(camera_uuid, parameters, overwrite).await?;
 
-            autopilot_reboot_required |= self
-                .update_focus_parameters(camera_uuid, parameters, overwrite)
-                .await?;
+            autopilot_reboot_required |=
+                Self::update_focus_parameters(camera_uuid, parameters, overwrite).await?;
 
-            autopilot_reboot_required |= self
-                .update_zoom_parameters(camera_uuid, parameters, overwrite)
-                .await?;
+            autopilot_reboot_required |=
+                Self::update_zoom_parameters(camera_uuid, parameters, overwrite).await?;
 
-            autopilot_reboot_required |= self
-                .update_tilt_parameters(camera_uuid, parameters, overwrite)
-                .await?;
+            autopilot_reboot_required |=
+                Self::update_tilt_parameters(camera_uuid, parameters, overwrite).await?;
         }
 
         let mut reload_script = overwrite;
 
-        // Callibration update
         if let Some(points) = &new_config.closest_points {
-            reload_script |= self
-                .update_closest_points(camera_uuid, points, overwrite)
-                .await?;
+            reload_script |= Self::update_closest_points(camera_uuid, points, overwrite).await?;
         }
         if let Some(points) = &new_config.furthest_points {
-            reload_script |= self
-                .update_furthest_points(camera_uuid, points, overwrite)
-                .await?;
+            reload_script |= Self::update_furthest_points(camera_uuid, points, overwrite).await?;
         }
 
-        reload_script |= self.export_script(camera_uuid, overwrite).await?;
+        // File write only — disk settings save is deferred to finalize / no-reboot path.
+        reload_script |= Self::export_script(camera_uuid, overwrite).await?;
 
         autopilot_reboot_required |= crate::mavlink::component()?
             .enable_lua_script(overwrite)
@@ -195,34 +209,44 @@ impl Manager {
         }
 
         if autopilot_reboot_required {
-            crate::mavlink::component()?.reboot_autopilot().await?;
+            // Caller drops CONFIG_APPLY, reboots, then calls finalize_config_after_reboot.
+            return Ok(true);
         }
 
-        // Re-push ENABLE/GAIN only when the Lua script was rewritten/reloaded (or a
-        // full overwrite/reboot), so a correlation toggle does not force a GAIN
-        // round-trip under the manager write lock.
-        let force_script_params = reload_script || overwrite || autopilot_reboot_required;
+        let force_script_params = reload_script || overwrite;
         if let Some(parameters) = &new_config.parameters {
-            self.update_script_enable(camera_uuid, parameters, force_script_params)
-                .await?;
-
-            self.update_script_gain(camera_uuid, parameters, force_script_params)
-                .await?;
+            Self::update_script_enable(camera_uuid, parameters, force_script_params).await?;
+            Self::update_script_gain(camera_uuid, parameters, force_script_params).await?;
         }
 
-        self.settings.save().await?;
-
-        Ok(())
+        Self::save_actuators_settings().await?;
+        Ok(false)
     }
 
-    #[instrument(level = "debug", skip(self))]
-    pub async fn reset_config(&mut self, camera_uuid: &Uuid) -> Result<()> {
+    /// Post-reboot enable/gain push and settings save. Caller must hold [`CONFIG_APPLY`].
+    #[instrument(level = "debug", skip(parameters))]
+    pub async fn finalize_config_after_reboot(
+        camera_uuid: &Uuid,
+        parameters: Option<&api::ActuatorsParametersConfig>,
+    ) -> Result<()> {
+        if let Some(parameters) = parameters {
+            Self::update_script_enable(camera_uuid, parameters, true).await?;
+            Self::update_script_gain(camera_uuid, parameters, true).await?;
+        }
+        Self::save_actuators_settings().await
+    }
+
+    #[instrument(level = "debug")]
+    pub async fn reset_config(camera_uuid: &Uuid) -> Result<bool> {
         let actuators = CameraActuators::default();
         let config = api::ActuatorsConfig::from(&actuators);
 
-        self.settings.actuators.insert(*camera_uuid, actuators);
+        {
+            let mut manager = MANAGER.get().context("Not available")?.write().await;
+            manager.settings.actuators.insert(*camera_uuid, actuators);
+        }
 
-        self.update_config(camera_uuid, &config, true).await
+        Self::update_config(camera_uuid, &config, true).await
     }
 }
 

--- a/backend/libs/autopilot/src/manager/mod.rs
+++ b/backend/libs/autopilot/src/manager/mod.rs
@@ -8,6 +8,7 @@ mod zoom;
 
 use ::mavlink::ardupilotmega::SERVO_OUTPUT_RAW_DATA;
 use anyhow::{Context, Result};
+use futures::future::BoxFuture;
 use indexmap::IndexMap;
 use once_cell::sync::OnceCell;
 use tokio::sync::RwLock;
@@ -31,17 +32,14 @@ pub static CONFIG_APPLY: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(
 
 /// Hold [`CONFIG_APPLY`] for `under_apply`. If it returns `true`, drop the mutex,
 /// run `reboot`, re-acquire, then run `finalize`.
-#[instrument(level = "debug", skip_all)]
-pub async fn reboot_outside_apply_with<U, R, F>(
-    under_apply: U,
-    reboot: R,
-    finalize: F,
-) -> Result<()>
-where
-    U: std::future::Future<Output = Result<bool>>,
-    R: std::future::Future<Output = Result<()>>,
-    F: std::future::Future<Output = Result<()>>,
-{
+///
+/// Futures are type-erased (`BoxFuture`) so composing this into instrumented
+/// `handle_control` / WS spawn paths does not overflow rustc's Send recursion limit.
+pub async fn reboot_outside_apply_with(
+    under_apply: BoxFuture<'_, Result<bool>>,
+    reboot: BoxFuture<'_, Result<()>>,
+    finalize: BoxFuture<'_, Result<()>>,
+) -> Result<()> {
     let mut apply = CONFIG_APPLY.lock().await;
     let needs_reboot = under_apply.await?;
     if needs_reboot {
@@ -56,14 +54,13 @@ where
 
 /// Hold [`CONFIG_APPLY`] for `under_apply`. If it returns `true`, drop the mutex,
 /// reboot the autopilot, re-acquire, then run `finalize`.
-pub async fn reboot_outside_apply<U, F>(under_apply: U, finalize: F) -> Result<()>
-where
-    U: std::future::Future<Output = Result<bool>>,
-    F: std::future::Future<Output = Result<()>>,
-{
+pub async fn reboot_outside_apply(
+    under_apply: BoxFuture<'_, Result<bool>>,
+    finalize: BoxFuture<'_, Result<()>>,
+) -> Result<()> {
     reboot_outside_apply_with(
         under_apply,
-        async { crate::mavlink::component()?.reboot_autopilot().await },
+        Box::pin(async { crate::mavlink::component()?.reboot_autopilot().await }),
         finalize,
     )
     .await
@@ -79,21 +76,21 @@ mod apply_tests {
     async fn finalize_runs_only_after_reboot_when_needed() {
         let phase = AtomicUsize::new(0);
         reboot_outside_apply_with(
-            async {
+            Box::pin(async {
                 assert_eq!(phase.load(Ordering::SeqCst), 0);
                 phase.store(1, Ordering::SeqCst);
                 Ok(true)
-            },
-            async {
+            }),
+            Box::pin(async {
                 assert_eq!(phase.load(Ordering::SeqCst), 1);
                 phase.store(2, Ordering::SeqCst);
                 Ok(())
-            },
-            async {
+            }),
+            Box::pin(async {
                 assert_eq!(phase.load(Ordering::SeqCst), 2);
                 phase.store(3, Ordering::SeqCst);
                 Ok(())
-            },
+            }),
         )
         .await
         .unwrap();
@@ -104,14 +101,14 @@ mod apply_tests {
     async fn finalize_skipped_when_no_reboot() {
         let finalized = AtomicUsize::new(0);
         reboot_outside_apply_with(
-            async { Ok(false) },
-            async {
+            Box::pin(async { Ok(false) }),
+            Box::pin(async {
                 panic!("reboot must not run");
-            },
-            async {
+            }),
+            Box::pin(async {
                 finalized.fetch_add(1, Ordering::SeqCst);
                 Ok(())
-            },
+            }),
         )
         .await
         .unwrap();

--- a/backend/libs/autopilot/src/manager/script.rs
+++ b/backend/libs/autopilot/src/manager/script.rs
@@ -17,20 +17,25 @@ pub const PARAM_PREFIX: &str = "RCAM";
 const SCRIPT_HEALTH_STALE_THRESHOLD: u8 = 3;
 
 impl Manager {
-    #[instrument(level = "debug", skip(self))]
-    pub async fn export_script(&mut self, camera_uuid: &Uuid, overwrite: bool) -> Result<bool> {
-        let camera_actuators = self
-            .settings
-            .actuators
-            .get(camera_uuid)
-            .context(crate::ACTUATORS_NOT_CONFIGURED)?;
-        let path = &self.autopilot_scripts_file;
+    #[instrument(level = "debug")]
+    pub async fn export_script(camera_uuid: &Uuid, overwrite: bool) -> Result<bool> {
+        let (contents, path) = {
+            let manager = crate::manager::MANAGER
+                .get()
+                .context("Not available")?
+                .read()
+                .await;
+            let camera_actuators = manager
+                .settings
+                .actuators
+                .get(camera_uuid)
+                .context(crate::ACTUATORS_NOT_CONFIGURED)?;
+            let contents = generate_lua_script(camera_actuators)?;
+            validate_lua(&contents)?;
+            (contents, manager.autopilot_scripts_file.clone())
+        };
 
-        let contents = generate_lua_script(camera_actuators)?;
-
-        validate_lua(&contents)?;
-
-        let path_obj = std::path::Path::new(path);
+        let path_obj = std::path::Path::new(&path);
         if let Some(parent_dir) = path_obj.parent() {
             tokio::fs::create_dir_all(parent_dir).await?;
         }
@@ -52,9 +57,7 @@ impl Manager {
             })?;
 
         info!("Wrote new lua script to {path:?}");
-
-        self.settings.save().await?;
-
+        // Settings save is deferred to update_config finalize / ExportLuaScript caller.
         Ok(true)
     }
 
@@ -87,9 +90,8 @@ impl Manager {
         Ok(())
     }
 
-    #[instrument(level = "debug", skip(self, parameters))]
+    #[instrument(level = "debug", skip(parameters))]
     pub async fn update_script_parameters(
-        &mut self,
         camera_uuid: &Uuid,
         parameters: &api::ActuatorsParametersConfig,
         overwrite: bool,
@@ -97,22 +99,31 @@ impl Manager {
         let mut autopilot_reboot_required = overwrite;
 
         if let Some(channel) = &parameters.script_channel {
-            let current_parameters = &mut self
-                .settings
-                .actuators
-                .entry(*camera_uuid)
-                .or_default()
-                .parameters;
-            let encoding = crate::mavlink::component()?.encoding().await;
+            // Snapshot under a short write with no await inside, so the MAVLink I/O
+            // below never runs while MANAGER is locked.
+            let old_channel = {
+                let mut manager = crate::manager::MANAGER
+                    .get()
+                    .context("Not available")?
+                    .write()
+                    .await;
+                manager
+                    .settings
+                    .actuators
+                    .entry(*camera_uuid)
+                    .or_default()
+                    .parameters
+                    .script_channel
+            };
+
+            let mavlink = crate::mavlink::component()?;
+            let encoding = mavlink.encoding().await;
 
             // Disables the old script_channel:
-            if &current_parameters.script_channel != channel {
-                let param_name =
-                    format!("SERVO{}_FUNCTION", current_parameters.script_channel as u8);
+            if &old_channel != channel {
+                let param_name = format!("SERVO{}_FUNCTION", old_channel as u8);
 
-                let mut param = crate::mavlink::component()?
-                    .get_param(&param_name, false)
-                    .await?;
+                let mut param = mavlink.get_param(&param_name, false).await?;
                 let old_value = param.value;
                 param
                     .value
@@ -120,15 +131,13 @@ impl Manager {
                 let new_value = param.value;
 
                 if old_value != new_value {
-                    match crate::mavlink::component()?.set_param(param).await {
+                    match mavlink.set_param(param).await {
                         Ok(_) => {
-                            if old_value != new_value {
-                                info!(
-                                    "script_channel (SERVO{}) changed from {old_value:?} to {new_value:?}",
-                                    current_parameters.script_channel as u8,
-                                );
-                                autopilot_reboot_required = true;
-                            }
+                            info!(
+                                "script_channel (SERVO{}) changed from {old_value:?} to {new_value:?}",
+                                old_channel as u8,
+                            );
+                            autopilot_reboot_required = true;
                         }
                         Err(error) => {
                             return Err(error).context(
@@ -146,9 +155,7 @@ impl Manager {
                 // The script servo input is the values from the CameraFocus
                 let function = ChannelFunction::CameraFocus;
 
-                let mut param = crate::mavlink::component()?
-                    .get_param(&param_name, false)
-                    .await?;
+                let mut param = mavlink.get_param(&param_name, false).await?;
                 let old_value = param.value;
                 param
                     .value
@@ -156,16 +163,22 @@ impl Manager {
                 let new_value = param.value;
 
                 if overwrite || old_value != new_value {
-                    match crate::mavlink::component()?.set_param(param).await {
+                    match mavlink.set_param(param).await {
                         Ok(_) => {
-                            if overwrite || old_value != new_value {
-                                info!(
-                                    "script_channel (SERVO{}) changed from {old_value:?} to {new_value:?}",
-                                    *channel as u8
-                                );
-                            }
+                            info!(
+                                "script_channel (SERVO{}) changed from {old_value:?} to {new_value:?}",
+                                *channel as u8
+                            );
 
-                            current_parameters.script_channel = *channel;
+                            let mut manager = crate::manager::MANAGER
+                                .get()
+                                .context("Not available")?
+                                .write()
+                                .await;
+                            if let Some(actuators) = manager.settings.actuators.get_mut(camera_uuid)
+                            {
+                                actuators.parameters.script_channel = *channel;
+                            }
                             autopilot_reboot_required = true;
                         }
                         Err(error) => {
@@ -178,50 +191,57 @@ impl Manager {
             }
         }
 
-        self.update_script_channel_parameters(camera_uuid, parameters, autopilot_reboot_required)
+        Self::update_script_channel_parameters(camera_uuid, parameters, autopilot_reboot_required)
             .await?;
 
         Ok(autopilot_reboot_required)
     }
 
     pub async fn update_script_enable(
-        &mut self,
         camera_uuid: &Uuid,
         parameters: &api::ActuatorsParametersConfig,
         force_apply: bool,
     ) -> Result<()> {
-        let current_parameters = &mut self
-            .settings
-            .actuators
-            .entry(*camera_uuid)
-            .or_default()
-            .parameters;
+        let (param_name, new_value, old_value) = {
+            let mut manager = crate::manager::MANAGER
+                .get()
+                .context("Not available")?
+                .write()
+                .await;
+            let current_parameters = &mut manager
+                .settings
+                .actuators
+                .entry(*camera_uuid)
+                .or_default()
+                .parameters;
 
-        let channel = current_parameters.camera_id as u8;
+            let channel = current_parameters.camera_id as u8;
 
-        let param_name = format!("{PARAM_PREFIX}{channel}_ENABLE");
+            let param_name = format!("{PARAM_PREFIX}{channel}_ENABLE");
 
-        let new_value = match (parameters.enable_focus_and_zoom_correlation, force_apply) {
-            (Some(value), _) => value,
-            (None, true) => current_parameters.enable_focus_and_zoom_correlation,
-            (None, false) => return Ok(()),
+            let new_value = match (parameters.enable_focus_and_zoom_correlation, force_apply) {
+                (Some(value), _) => value,
+                (None, true) => current_parameters.enable_focus_and_zoom_correlation,
+                (None, false) => return Ok(()),
+            };
+
+            let old_value = current_parameters.enable_focus_and_zoom_correlation;
+            (param_name, new_value, old_value)
         };
 
-        let old_value = current_parameters.enable_focus_and_zoom_correlation;
         if !force_apply && old_value == new_value {
             trace!("Parameter {param_name:?} skipped");
             return Ok(());
         }
 
-        let encoding = crate::mavlink::component()?.encoding().await;
-        let mut param = crate::mavlink::component()?
-            .get_param(&param_name, false)
-            .await?;
+        let mavlink = crate::mavlink::component()?;
+        let encoding = mavlink.encoding().await;
+        let mut param = mavlink.get_param(&param_name, false).await?;
         param
             .value
             .set_value(ParamType::UINT8(new_value as u8), encoding)?;
 
-        match crate::mavlink::component()?.set_param(param).await {
+        match mavlink.set_param(param).await {
             Ok(_) => {
                 if old_value != new_value {
                     info!(
@@ -229,7 +249,14 @@ impl Manager {
                         stringify!(enable_focus_and_zoom_correlation),
                     );
                 }
-                current_parameters.enable_focus_and_zoom_correlation = new_value;
+                let mut manager = crate::manager::MANAGER
+                    .get()
+                    .context("Not available")?
+                    .write()
+                    .await;
+                if let Some(actuators) = manager.settings.actuators.get_mut(camera_uuid) {
+                    actuators.parameters.enable_focus_and_zoom_correlation = new_value;
+                }
             }
             Err(error) => {
                 return Err(error).context(format!("Failed setting parameter {param_name}"));
@@ -240,43 +267,50 @@ impl Manager {
     }
 
     pub async fn update_script_gain(
-        &mut self,
         camera_uuid: &Uuid,
         parameters: &api::ActuatorsParametersConfig,
         force_apply: bool,
     ) -> Result<()> {
-        let current_parameters = &mut self
-            .settings
-            .actuators
-            .entry(*camera_uuid)
-            .or_default()
-            .parameters;
+        let (param_name, new_value, old_value) = {
+            let mut manager = crate::manager::MANAGER
+                .get()
+                .context("Not available")?
+                .write()
+                .await;
+            let current_parameters = &mut manager
+                .settings
+                .actuators
+                .entry(*camera_uuid)
+                .or_default()
+                .parameters;
 
-        let channel = current_parameters.camera_id as u8;
+            let channel = current_parameters.camera_id as u8;
 
-        let param_name = format!("{PARAM_PREFIX}{channel}_GAIN");
+            let param_name = format!("{PARAM_PREFIX}{channel}_GAIN");
 
-        let new_value = match (parameters.focus_margin_gain, force_apply) {
-            (Some(value), _) => value,
-            (None, true) => current_parameters.focus_margin_gain,
-            (None, false) => return Ok(()),
+            let new_value = match (parameters.focus_margin_gain, force_apply) {
+                (Some(value), _) => value,
+                (None, true) => current_parameters.focus_margin_gain,
+                (None, false) => return Ok(()),
+            };
+
+            let old_value = current_parameters.focus_margin_gain;
+            (param_name, new_value, old_value)
         };
 
-        let old_value = current_parameters.focus_margin_gain;
         if !force_apply && old_value == new_value {
             trace!("Parameter {param_name:?} skipped");
             return Ok(());
         }
 
-        let encoding = crate::mavlink::component()?.encoding().await;
-        let mut param = crate::mavlink::component()?
-            .get_param(&param_name, false)
-            .await?;
+        let mavlink = crate::mavlink::component()?;
+        let encoding = mavlink.encoding().await;
+        let mut param = mavlink.get_param(&param_name, false).await?;
         param
             .value
             .set_value(ParamType::UINT8(new_value as u8), encoding)?;
 
-        match crate::mavlink::component()?.set_param(param).await {
+        match mavlink.set_param(param).await {
             Ok(_) => {
                 if old_value != new_value {
                     info!(
@@ -284,7 +318,14 @@ impl Manager {
                         stringify!(focus_margin_gain),
                     );
                 }
-                current_parameters.focus_margin_gain = new_value;
+                let mut manager = crate::manager::MANAGER
+                    .get()
+                    .context("Not available")?
+                    .write()
+                    .await;
+                if let Some(actuators) = manager.settings.actuators.get_mut(camera_uuid) {
+                    actuators.parameters.focus_margin_gain = new_value;
+                }
             }
             Err(error) => {
                 return Err(error).context(format!("Failed setting parameter {param_name}"));
@@ -294,19 +335,15 @@ impl Manager {
         Ok(())
     }
 
-    #[instrument(level = "debug", skip(self, parameters))]
+    #[instrument(level = "debug", skip(parameters))]
     pub async fn update_script_channel_parameters(
-        &mut self,
         camera_uuid: &Uuid,
         parameters: &api::ActuatorsParametersConfig,
         force_apply: bool,
     ) -> Result<()> {
-        self.update_script_channel_min(camera_uuid, parameters, force_apply)
-            .await?;
-        self.update_script_channel_trim(camera_uuid, parameters, force_apply)
-            .await?;
-        self.update_script_channel_max(camera_uuid, parameters, force_apply)
-            .await?;
+        Self::update_script_channel_min(camera_uuid, parameters, force_apply).await?;
+        Self::update_script_channel_trim(camera_uuid, parameters, force_apply).await?;
+        Self::update_script_channel_max(camera_uuid, parameters, force_apply).await?;
 
         Ok(())
     }

--- a/backend/libs/autopilot/src/manager/script.rs
+++ b/backend/libs/autopilot/src/manager/script.rs
@@ -61,11 +61,11 @@ impl Manager {
         Ok(true)
     }
 
-    #[instrument(level = "debug", skip(self))]
-    pub async fn remove_script(&self) -> Result<()> {
-        let path = std::path::Path::new(&self.autopilot_scripts_file);
+    #[instrument(level = "debug")]
+    pub async fn delete_script_file(path: &str) -> Result<()> {
+        let path_obj = std::path::Path::new(path);
 
-        match tokio::fs::remove_file(path).await {
+        match tokio::fs::remove_file(path_obj).await {
             Ok(()) => info!("Removed lua script at {path:?}"),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                 trace!("No lua script to remove at {path:?}");
@@ -76,6 +76,13 @@ impl Manager {
             }
         }
 
+        Ok(())
+    }
+
+    /// Disable scripting (or reload if no reboot needed). Returns `true` if reboot is required.
+    /// Does not reboot and does not hold [`crate::manager::MANAGER`].
+    #[instrument(level = "debug")]
+    pub async fn disable_or_reload_lua() -> Result<bool> {
         let autopilot_reboot_required =
             crate::mavlink::component()?.enable_lua_script(true).await?;
 
@@ -83,11 +90,9 @@ impl Manager {
             crate::mavlink::component()?
                 .reload_lua_scripts(true)
                 .await?;
-        } else {
-            crate::mavlink::component()?.reboot_autopilot().await?;
         }
 
-        Ok(())
+        Ok(autopilot_reboot_required)
     }
 
     #[instrument(level = "debug", skip(parameters))]
@@ -197,6 +202,7 @@ impl Manager {
         Ok(autopilot_reboot_required)
     }
 
+    #[instrument(level = "debug", skip(parameters))]
     pub async fn update_script_enable(
         camera_uuid: &Uuid,
         parameters: &api::ActuatorsParametersConfig,
@@ -266,6 +272,7 @@ impl Manager {
         Ok(())
     }
 
+    #[instrument(level = "debug", skip(parameters))]
     pub async fn update_script_gain(
         camera_uuid: &Uuid,
         parameters: &api::ActuatorsParametersConfig,

--- a/backend/libs/autopilot/src/manager/tilt.rs
+++ b/backend/libs/autopilot/src/manager/tilt.rs
@@ -117,25 +117,22 @@ impl Manager {
         }
 
         Self::update_tilt_channel_parameters(camera_uuid, parameters, autopilot_reboot_required)
-            .await?;
-
-        Ok(autopilot_reboot_required)
+            .await
+            .map(|reboot| autopilot_reboot_required | reboot)
     }
     #[instrument(level = "debug", skip(parameters))]
     pub async fn update_tilt_channel_parameters(
         camera_uuid: &Uuid,
         parameters: &api::ActuatorsParametersConfig,
         force_apply: bool,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         Self::update_tilt_channel_min(camera_uuid, parameters, force_apply).await?;
         Self::update_tilt_channel_trim(camera_uuid, parameters, force_apply).await?;
         Self::update_tilt_channel_max(camera_uuid, parameters, force_apply).await?;
 
         Self::update_tilt_mnt_pitch_min(camera_uuid, parameters, force_apply).await?;
         Self::update_tilt_mnt_pitch_max(camera_uuid, parameters, force_apply).await?;
-        Self::update_tilt_mnt_type(camera_uuid, parameters, force_apply).await?;
-
-        Ok(())
+        Self::update_tilt_mnt_type(camera_uuid, parameters, force_apply).await
     }
 
     generate_update_channel_param_function!(
@@ -184,7 +181,7 @@ impl Manager {
         camera_uuid: &Uuid,
         parameters: &api::ActuatorsParametersConfig,
         force_apply: bool,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         let (param_name, new_value, old_value) = {
             let mut manager = crate::manager::MANAGER
                 .get()
@@ -208,7 +205,7 @@ impl Manager {
             let new_value = match (parameters.tilt_mnt_type, force_apply) {
                 (Some(value), _) => value,
                 (None, true) => current_parameters.tilt_mnt_type,
-                (None, false) => return Ok(()),
+                (None, false) => return Ok(false),
             };
 
             (param_name, new_value, current_parameters.tilt_mnt_type)
@@ -241,8 +238,8 @@ impl Manager {
                     if let Some(actuators) = manager.settings.actuators.get_mut(camera_uuid) {
                         actuators.parameters.tilt_mnt_type = new_value;
                     }
-
-                    // TODO: Reboot required after change!
+                    // Mount type changes require an autopilot reboot to take effect.
+                    return Ok(old_value_encoded != new_value_encoded || force_apply);
                 }
                 Err(error) => {
                     return Err(error).context(format!("Failed setting parameter {param_name}"));
@@ -250,6 +247,6 @@ impl Manager {
             }
         }
 
-        Ok(())
+        Ok(false)
     }
 }

--- a/backend/libs/autopilot/src/manager/tilt.rs
+++ b/backend/libs/autopilot/src/manager/tilt.rs
@@ -10,9 +10,8 @@ use crate::{
 };
 
 impl Manager {
-    #[instrument(level = "debug", skip(self, parameters))]
+    #[instrument(level = "debug", skip(parameters))]
     pub async fn update_tilt_parameters(
-        &mut self,
         camera_uuid: &Uuid,
         parameters: &api::ActuatorsParametersConfig,
         overwrite: bool,
@@ -20,21 +19,34 @@ impl Manager {
         let mut autopilot_reboot_required = overwrite;
 
         if let Some(channel) = &parameters.tilt_channel {
-            let current_parameters = &mut self
-                .settings
-                .actuators
-                .entry(*camera_uuid)
-                .or_default()
-                .parameters;
-            let encoding = crate::mavlink::component()?.encoding().await;
+            // Snapshot under a short write with no await inside, so the MAVLink I/O
+            // below never runs while MANAGER is locked.
+            let (old_channel, camera_id) = {
+                let mut manager = crate::manager::MANAGER
+                    .get()
+                    .context("Not available")?
+                    .write()
+                    .await;
+                let current_parameters = &mut manager
+                    .settings
+                    .actuators
+                    .entry(*camera_uuid)
+                    .or_default()
+                    .parameters;
+                (
+                    current_parameters.tilt_channel,
+                    current_parameters.camera_id,
+                )
+            };
+
+            let mavlink = crate::mavlink::component()?;
+            let encoding = mavlink.encoding().await;
 
             // Disables the old tilt_channel:
-            if &current_parameters.tilt_channel != channel {
-                let param_name = format!("SERVO{}_FUNCTION", current_parameters.tilt_channel as u8);
+            if &old_channel != channel {
+                let param_name = format!("SERVO{}_FUNCTION", old_channel as u8);
 
-                let mut param = crate::mavlink::component()?
-                    .get_param(&param_name, false)
-                    .await?;
+                let mut param = mavlink.get_param(&param_name, false).await?;
                 let old_value = param.value;
                 param
                     .value
@@ -42,15 +54,13 @@ impl Manager {
                 let new_value = param.value;
 
                 if old_value != new_value {
-                    match crate::mavlink::component()?.set_param(param).await {
+                    match mavlink.set_param(param).await {
                         Ok(_) => {
-                            if old_value != new_value {
-                                info!(
-                                    "tilt_channel (SERVO{}) changed from {:?} to {new_value:?}",
-                                    current_parameters.tilt_channel as u8, old_value
-                                );
-                                autopilot_reboot_required = true;
-                            }
+                            info!(
+                                "tilt_channel (SERVO{}) changed from {:?} to {new_value:?}",
+                                old_channel as u8, old_value
+                            );
+                            autopilot_reboot_required = true;
                         }
                         Err(error) => {
                             return Err(error).context(
@@ -65,14 +75,12 @@ impl Manager {
             {
                 let param_name = format!("SERVO{}_FUNCTION", *channel as u8);
 
-                let function = match current_parameters.camera_id {
+                let function = match camera_id {
                     api::CameraID::CAM1 => ChannelFunction::Mount1Pitch,
                     api::CameraID::CAM2 => ChannelFunction::Mount2Pitch,
                 };
 
-                let mut param = crate::mavlink::component()?
-                    .get_param(&param_name, false)
-                    .await?;
+                let mut param = mavlink.get_param(&param_name, false).await?;
                 let old_value = param.value;
                 param
                     .value
@@ -80,16 +88,22 @@ impl Manager {
                 let new_value = param.value;
 
                 if overwrite || old_value != new_value {
-                    match crate::mavlink::component()?.set_param(param).await {
+                    match mavlink.set_param(param).await {
                         Ok(_) => {
-                            if overwrite || old_value != new_value {
-                                info!(
-                                    "tilt_channel (SERVO{}) changed from {:?} to {new_value:?}",
-                                    *channel as u8, old_value
-                                );
-                            }
+                            info!(
+                                "tilt_channel (SERVO{}) changed from {:?} to {new_value:?}",
+                                *channel as u8, old_value
+                            );
 
-                            current_parameters.tilt_channel = *channel;
+                            let mut manager = crate::manager::MANAGER
+                                .get()
+                                .context("Not available")?
+                                .write()
+                                .await;
+                            if let Some(actuators) = manager.settings.actuators.get_mut(camera_uuid)
+                            {
+                                actuators.parameters.tilt_channel = *channel;
+                            }
                             autopilot_reboot_required = true;
                         }
                         Err(error) => {
@@ -102,31 +116,24 @@ impl Manager {
             }
         }
 
-        self.update_tilt_channel_parameters(camera_uuid, parameters, autopilot_reboot_required)
+        Self::update_tilt_channel_parameters(camera_uuid, parameters, autopilot_reboot_required)
             .await?;
 
         Ok(autopilot_reboot_required)
     }
-    #[instrument(level = "debug", skip(self, parameters))]
+    #[instrument(level = "debug", skip(parameters))]
     pub async fn update_tilt_channel_parameters(
-        &mut self,
         camera_uuid: &Uuid,
         parameters: &api::ActuatorsParametersConfig,
         force_apply: bool,
     ) -> Result<()> {
-        self.update_tilt_channel_min(camera_uuid, parameters, force_apply)
-            .await?;
-        self.update_tilt_channel_trim(camera_uuid, parameters, force_apply)
-            .await?;
-        self.update_tilt_channel_max(camera_uuid, parameters, force_apply)
-            .await?;
+        Self::update_tilt_channel_min(camera_uuid, parameters, force_apply).await?;
+        Self::update_tilt_channel_trim(camera_uuid, parameters, force_apply).await?;
+        Self::update_tilt_channel_max(camera_uuid, parameters, force_apply).await?;
 
-        self.update_tilt_mnt_pitch_min(camera_uuid, parameters, force_apply)
-            .await?;
-        self.update_tilt_mnt_pitch_max(camera_uuid, parameters, force_apply)
-            .await?;
-        self.update_tilt_mnt_type(camera_uuid, parameters, force_apply)
-            .await?;
+        Self::update_tilt_mnt_pitch_min(camera_uuid, parameters, force_apply).await?;
+        Self::update_tilt_mnt_pitch_max(camera_uuid, parameters, force_apply).await?;
+        Self::update_tilt_mnt_type(camera_uuid, parameters, force_apply).await?;
 
         Ok(())
     }
@@ -172,54 +179,68 @@ impl Manager {
         INT32
     );
 
-    #[instrument(level = "debug", skip(self))]
+    #[instrument(level = "debug")]
     pub async fn update_tilt_mnt_type(
-        &mut self,
         camera_uuid: &Uuid,
         parameters: &api::ActuatorsParametersConfig,
         force_apply: bool,
     ) -> Result<()> {
-        let current_parameters = &mut self
-            .settings
-            .actuators
-            .entry(*camera_uuid)
-            .or_default()
-            .parameters;
+        let (param_name, new_value, old_value) = {
+            let mut manager = crate::manager::MANAGER
+                .get()
+                .context("Not available")?
+                .write()
+                .await;
+            let current_parameters = &mut manager
+                .settings
+                .actuators
+                .entry(*camera_uuid)
+                .or_default()
+                .parameters;
 
-        let encoding = crate::mavlink::component()?.encoding().await;
+            // Debug name is MNT1/MNT2 (same as pitch macros), not the SERVO function u8.
+            let mount_id = match current_parameters.camera_id {
+                api::CameraID::CAM1 => TiltChannelFunction::MNT1,
+                api::CameraID::CAM2 => TiltChannelFunction::MNT2,
+            };
+            let param_name = format!("{mount_id:?}_TYPE");
 
-        // Debug name is MNT1/MNT2 (same as pitch macros), not the SERVO function u8.
-        let mount_id = match current_parameters.camera_id {
-            api::CameraID::CAM1 => TiltChannelFunction::MNT1,
-            api::CameraID::CAM2 => TiltChannelFunction::MNT2,
+            let new_value = match (parameters.tilt_mnt_type, force_apply) {
+                (Some(value), _) => value,
+                (None, true) => current_parameters.tilt_mnt_type,
+                (None, false) => return Ok(()),
+            };
+
+            (param_name, new_value, current_parameters.tilt_mnt_type)
         };
-        let param_name = format!("{mount_id:?}_TYPE");
 
-        let new_value = match (parameters.tilt_mnt_type, force_apply) {
-            (Some(value), _) => value,
-            (None, true) => current_parameters.tilt_mnt_type,
-            (None, false) => return Ok(()),
-        };
-        let mut param = crate::mavlink::component()?
-            .get_param(&param_name, false)
-            .await?;
+        let mavlink = crate::mavlink::component()?;
+        let encoding = mavlink.encoding().await;
+        let mut param = mavlink.get_param(&param_name, false).await?;
         let old_value_encoded = param.param_value(encoding)?;
         param
             .value
             .set_value(ParamType::INT32(new_value as i32), encoding)?;
         let new_value_encoded = param.param_value(encoding)?;
         if (old_value_encoded != new_value_encoded) || force_apply {
-            match crate::mavlink::component()?.set_param(param).await {
+            match mavlink.set_param(param).await {
                 Ok(_) => {
                     if old_value_encoded != new_value_encoded {
                         info!(
                             "{} changed from {:?} to {:?}",
                             stringify!(tilt_mnt_type),
-                            current_parameters.tilt_mnt_type,
+                            old_value,
                             new_value
                         );
                     }
-                    current_parameters.tilt_mnt_type = new_value;
+                    let mut manager = crate::manager::MANAGER
+                        .get()
+                        .context("Not available")?
+                        .write()
+                        .await;
+                    if let Some(actuators) = manager.settings.actuators.get_mut(camera_uuid) {
+                        actuators.parameters.tilt_mnt_type = new_value;
+                    }
 
                     // TODO: Reboot required after change!
                 }

--- a/backend/libs/autopilot/src/manager/zoom.rs
+++ b/backend/libs/autopilot/src/manager/zoom.rs
@@ -9,9 +9,8 @@ use crate::{
 };
 
 impl Manager {
-    #[instrument(level = "debug", skip(self, parameters))]
+    #[instrument(level = "debug", skip(parameters))]
     pub async fn update_zoom_parameters(
-        &mut self,
         camera_uuid: &Uuid,
         parameters: &api::ActuatorsParametersConfig,
         overwrite: bool,
@@ -19,21 +18,31 @@ impl Manager {
         let mut autopilot_reboot_required = overwrite;
 
         if let Some(channel) = &parameters.zoom_channel {
-            let current_parameters = &mut self
-                .settings
-                .actuators
-                .entry(*camera_uuid)
-                .or_default()
-                .parameters;
-            let encoding = crate::mavlink::component()?.encoding().await;
+            // Snapshot under a short write with no await inside, so the MAVLink I/O
+            // below never runs while MANAGER is locked.
+            let old_channel = {
+                let mut manager = crate::manager::MANAGER
+                    .get()
+                    .context("Not available")?
+                    .write()
+                    .await;
+                manager
+                    .settings
+                    .actuators
+                    .entry(*camera_uuid)
+                    .or_default()
+                    .parameters
+                    .zoom_channel
+            };
+
+            let mavlink = crate::mavlink::component()?;
+            let encoding = mavlink.encoding().await;
 
             // Disables the old zoom_channel:
-            if &current_parameters.zoom_channel != channel {
-                let param_name = format!("SERVO{}_FUNCTION", current_parameters.zoom_channel as u8);
+            if &old_channel != channel {
+                let param_name = format!("SERVO{}_FUNCTION", old_channel as u8);
 
-                let mut param = crate::mavlink::component()?
-                    .get_param(&param_name, false)
-                    .await?;
+                let mut param = mavlink.get_param(&param_name, false).await?;
                 let old_value = param.value;
                 param
                     .value
@@ -41,15 +50,13 @@ impl Manager {
                 let new_value = param.value;
 
                 if old_value != new_value {
-                    match crate::mavlink::component()?.set_param(param).await {
+                    match mavlink.set_param(param).await {
                         Ok(_) => {
-                            if old_value != new_value {
-                                info!(
-                                    "zoom_channel (SERVO{}) changed from {:?} to {new_value:?}",
-                                    current_parameters.zoom_channel as u8, old_value
-                                );
-                                autopilot_reboot_required = true;
-                            }
+                            info!(
+                                "zoom_channel (SERVO{}) changed from {:?} to {new_value:?}",
+                                old_channel as u8, old_value
+                            );
+                            autopilot_reboot_required = true;
                         }
                         Err(error) => {
                             return Err(error).context(
@@ -64,9 +71,7 @@ impl Manager {
             {
                 let param_name = format!("SERVO{}_FUNCTION", *channel as u8);
 
-                let mut param = crate::mavlink::component()?
-                    .get_param(&param_name, false)
-                    .await?;
+                let mut param = mavlink.get_param(&param_name, false).await?;
                 let old_value = param.value;
                 param.value.set_value(
                     ParamType::INT16(ChannelFunction::CameraZoom as i16),
@@ -75,16 +80,22 @@ impl Manager {
                 let new_value = param.value;
 
                 if overwrite || old_value != new_value {
-                    match crate::mavlink::component()?.set_param(param).await {
+                    match mavlink.set_param(param).await {
                         Ok(_) => {
-                            if overwrite || old_value != new_value {
-                                info!(
-                                    "zoom_channel (SERVO{}) changed from {:?} to {new_value:?}",
-                                    *channel as u8, old_value
-                                );
-                            }
+                            info!(
+                                "zoom_channel (SERVO{}) changed from {:?} to {new_value:?}",
+                                *channel as u8, old_value
+                            );
 
-                            current_parameters.zoom_channel = *channel;
+                            let mut manager = crate::manager::MANAGER
+                                .get()
+                                .context("Not available")?
+                                .write()
+                                .await;
+                            if let Some(actuators) = manager.settings.actuators.get_mut(camera_uuid)
+                            {
+                                actuators.parameters.zoom_channel = *channel;
+                            }
                             autopilot_reboot_required = true;
                         }
                         Err(error) => {
@@ -97,25 +108,21 @@ impl Manager {
             }
         }
 
-        self.update_zoom_channel_parameters(camera_uuid, parameters, autopilot_reboot_required)
+        Self::update_zoom_channel_parameters(camera_uuid, parameters, autopilot_reboot_required)
             .await?;
 
         Ok(autopilot_reboot_required)
     }
 
-    #[instrument(level = "debug", skip(self, parameters))]
+    #[instrument(level = "debug", skip(parameters))]
     pub async fn update_zoom_channel_parameters(
-        &mut self,
         camera_uuid: &Uuid,
         parameters: &api::ActuatorsParametersConfig,
         force_apply: bool,
     ) -> Result<()> {
-        self.update_zoom_channel_min(camera_uuid, parameters, force_apply)
-            .await?;
-        self.update_zoom_channel_trim(camera_uuid, parameters, force_apply)
-            .await?;
-        self.update_zoom_channel_max(camera_uuid, parameters, force_apply)
-            .await?;
+        Self::update_zoom_channel_min(camera_uuid, parameters, force_apply).await?;
+        Self::update_zoom_channel_trim(camera_uuid, parameters, force_apply).await?;
+        Self::update_zoom_channel_max(camera_uuid, parameters, force_apply).await?;
 
         Ok(())
     }

--- a/backend/libs/autopilot/src/mavlink/mod.rs
+++ b/backend/libs/autopilot/src/mavlink/mod.rs
@@ -370,12 +370,12 @@ impl MavlinkComponent {
             match tokio::time::timeout(tokio::time::Duration::from_secs(1), wait_command_ack).await
             {
                 Ok(Ok(())) => return Ok(()),
-                Ok(Err(err)) => {
-                    if err.to_string().contains("MAV_RESULT_UNSUPPORTED") {
+                Ok(Err(error)) => {
+                    if error.to_string().contains("MAV_RESULT_UNSUPPORTED") {
                         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
                         continue;
                     }
-                    return Err(err);
+                    return Err(error);
                 }
                 Err(_) => {
                     warn!("Timeout for command {:?}, retrying", command.command);
@@ -414,6 +414,7 @@ impl MavlinkComponent {
     }
 
     /// One-shot request for `SERVO_OUTPUT_RAW`. Holds the mavlink txn for the whole RPC.
+    #[instrument(level = "debug", skip(self))]
     pub async fn request_servo_output_raw(&self) -> Result<SERVO_OUTPUT_RAW_DATA> {
         let target_system = self.inner.system_id;
         let target_component = mavlink::ardupilotmega::MavComponent::MAV_COMP_ID_AUTOPILOT1 as u8;

--- a/backend/libs/autopilot/src/mavlink/parameters.rs
+++ b/backend/libs/autopilot/src/mavlink/parameters.rs
@@ -92,10 +92,7 @@ impl MavlinkComponent {
 
             let encoding_c_cast = data
                 .capabilities
-                .contains(MavProtocolCapability::MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT)
-                || data
-                    .capabilities
-                    .contains(MavProtocolCapability::MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_C_CAST);
+                .contains(MavProtocolCapability::MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_C_CAST);
             let encoding_bytewise = data
                 .capabilities
                 .contains(MavProtocolCapability::MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_BYTEWISE);

--- a/backend/libs/autopilot/src/mod.rs
+++ b/backend/libs/autopilot/src/mod.rs
@@ -67,12 +67,10 @@ pub(crate) async fn control_inner(
     let res = match &actuators_control.action {
         Action::ExportLuaScript => {
             let _apply = manager::CONFIG_APPLY.lock().await;
-            let reload_script = {
-                let mut manager = MANAGER.get().context("Not available")?.write().await;
-                manager
-                    .export_script(&actuators_control.camera_uuid, true)
-                    .await?
-            };
+            let reload_script =
+                manager::Manager::export_script(&actuators_control.camera_uuid, true).await?;
+            manager::Manager::save_actuators_settings().await?;
+            drop(_apply);
 
             if reload_script {
                 crate::mavlink::component()?
@@ -224,46 +222,65 @@ pub(crate) async fn control_inner(
             serde_json::to_value(config)?
         }
         Action::SetActuatorsConfig(new_config) => {
-            let _apply = manager::CONFIG_APPLY.lock().await;
-            let mut manager = MANAGER.get().context("Not available")?.write().await;
-            let mut new_config = new_config.to_owned();
+            let camera_uuid = actuators_control.camera_uuid;
+            let mut apply = manager::CONFIG_APPLY.lock().await;
+            let new_config = {
+                let manager = MANAGER.get().context("Not available")?.read().await;
+                let base_config = manager
+                    .settings
+                    .actuators
+                    .get(&camera_uuid)
+                    .map(api::ActuatorsConfig::from)
+                    .unwrap_or(api::ActuatorsConfig::from(&CameraActuators::default()));
+                merge_struct::merge(&base_config, new_config).context("Failing to merge structs")?
+            };
 
-            let base_config = &manager
-                .settings
-                .actuators
-                .get(&actuators_control.camera_uuid)
-                .map(api::ActuatorsConfig::from)
-                .unwrap_or(api::ActuatorsConfig::from(&CameraActuators::default()));
-
-            new_config = merge_struct::merge(base_config, &new_config.clone())
-                .context("Failing to merge structs")?;
-
-            // ponytail: still holds MANAGER.write across param I/O — CONFIG_APPLY
-            // serializes mutators; full snapshot-I/O-commit of hand-written channel
-            // swaps is the upgrade path.
-            manager
-                .update_config(&actuators_control.camera_uuid, &new_config, false)
+            let needs_reboot =
+                manager::Manager::update_config(&camera_uuid, &new_config, false).await?;
+            if needs_reboot {
+                drop(apply);
+                crate::mavlink::component()?.reboot_autopilot().await?;
+                apply = manager::CONFIG_APPLY.lock().await;
+                manager::Manager::finalize_config_after_reboot(
+                    &camera_uuid,
+                    new_config.parameters.as_ref(),
+                )
                 .await?;
+            }
+            drop(apply);
 
+            let manager = MANAGER.get().context("Not available")?.read().await;
             let config: &api::ActuatorsConfig = &manager
                 .settings
                 .actuators
-                .get(&actuators_control.camera_uuid)
+                .get(&camera_uuid)
                 .context(crate::ACTUATORS_NOT_CONFIGURED)?
                 .into();
 
             serde_json::to_value(config)?
         }
         Action::ResetActuatorsConfig => {
-            let _apply = manager::CONFIG_APPLY.lock().await;
-            let mut manager = MANAGER.get().context("Not available")?.write().await;
+            let camera_uuid = actuators_control.camera_uuid;
+            let mut apply = manager::CONFIG_APPLY.lock().await;
+            let needs_reboot = manager::Manager::reset_config(&camera_uuid).await?;
+            if needs_reboot {
+                drop(apply);
+                crate::mavlink::component()?.reboot_autopilot().await?;
+                apply = manager::CONFIG_APPLY.lock().await;
+                let default_params = api::ActuatorsConfig::from(&CameraActuators::default());
+                manager::Manager::finalize_config_after_reboot(
+                    &camera_uuid,
+                    default_params.parameters.as_ref(),
+                )
+                .await?;
+            }
+            drop(apply);
 
-            manager.reset_config(&actuators_control.camera_uuid).await?;
-
+            let manager = MANAGER.get().context("Not available")?.read().await;
             let config: &api::ActuatorsConfig = &manager
                 .settings
                 .actuators
-                .get(&actuators_control.camera_uuid)
+                .get(&camera_uuid)
                 .context(crate::ACTUATORS_NOT_CONFIGURED)?
                 .into();
 

--- a/backend/libs/autopilot/src/mod.rs
+++ b/backend/libs/autopilot/src/mod.rs
@@ -66,24 +66,22 @@ pub(crate) async fn control_inner(
 
     let res = match &actuators_control.action {
         Action::ExportLuaScript => {
-            let _apply = manager::CONFIG_APPLY.lock().await;
-            let reload_script =
-                manager::Manager::export_script(&actuators_control.camera_uuid, true).await?;
-            manager::Manager::save_actuators_settings().await?;
-            drop(_apply);
-
-            if reload_script {
-                crate::mavlink::component()?
-                    .reload_lua_scripts(true)
-                    .await?;
-            }
-
-            let autopilot_reboot_required = crate::mavlink::component()?
-                .enable_lua_script(false)
-                .await?;
-            if autopilot_reboot_required {
-                crate::mavlink::component()?.reboot_autopilot().await?;
-            }
+            let camera_uuid = actuators_control.camera_uuid;
+            manager::reboot_outside_apply(
+                async {
+                    let reload_script = manager::Manager::export_script(&camera_uuid, true).await?;
+                    manager::Manager::save_actuators_settings().await?;
+                    if reload_script {
+                        crate::mavlink::component()?
+                            .reload_lua_scripts(true)
+                            .await?;
+                    }
+                    crate::mavlink::component()?.enable_lua_script(false).await
+                },
+                // Export already saved under apply; post-reboot finalize is a no-op.
+                async { Ok(()) },
+            )
+            .await?;
 
             serde_json::to_value({})?
         }
@@ -223,7 +221,6 @@ pub(crate) async fn control_inner(
         }
         Action::SetActuatorsConfig(new_config) => {
             let camera_uuid = actuators_control.camera_uuid;
-            let mut apply = manager::CONFIG_APPLY.lock().await;
             let new_config = {
                 let manager = MANAGER.get().context("Not available")?.read().await;
                 let base_config = manager
@@ -235,19 +232,17 @@ pub(crate) async fn control_inner(
                 merge_struct::merge(&base_config, new_config).context("Failing to merge structs")?
             };
 
-            let needs_reboot =
-                manager::Manager::update_config(&camera_uuid, &new_config, false).await?;
-            if needs_reboot {
-                drop(apply);
-                crate::mavlink::component()?.reboot_autopilot().await?;
-                apply = manager::CONFIG_APPLY.lock().await;
-                manager::Manager::finalize_config_after_reboot(
-                    &camera_uuid,
-                    new_config.parameters.as_ref(),
-                )
-                .await?;
-            }
-            drop(apply);
+            manager::reboot_outside_apply(
+                async { manager::Manager::update_config(&camera_uuid, &new_config, false).await },
+                async {
+                    manager::Manager::finalize_config_after_reboot(
+                        &camera_uuid,
+                        new_config.parameters.as_ref(),
+                    )
+                    .await
+                },
+            )
+            .await?;
 
             let manager = MANAGER.get().context("Not available")?.read().await;
             let config: &api::ActuatorsConfig = &manager
@@ -261,20 +256,18 @@ pub(crate) async fn control_inner(
         }
         Action::ResetActuatorsConfig => {
             let camera_uuid = actuators_control.camera_uuid;
-            let mut apply = manager::CONFIG_APPLY.lock().await;
-            let needs_reboot = manager::Manager::reset_config(&camera_uuid).await?;
-            if needs_reboot {
-                drop(apply);
-                crate::mavlink::component()?.reboot_autopilot().await?;
-                apply = manager::CONFIG_APPLY.lock().await;
-                let default_params = api::ActuatorsConfig::from(&CameraActuators::default());
-                manager::Manager::finalize_config_after_reboot(
-                    &camera_uuid,
-                    default_params.parameters.as_ref(),
-                )
-                .await?;
-            }
-            drop(apply);
+            let default_params = api::ActuatorsConfig::from(&CameraActuators::default());
+            manager::reboot_outside_apply(
+                async { manager::Manager::reset_config(&camera_uuid).await },
+                async {
+                    manager::Manager::finalize_config_after_reboot(
+                        &camera_uuid,
+                        default_params.parameters.as_ref(),
+                    )
+                    .await
+                },
+            )
+            .await?;
 
             let manager = MANAGER.get().context("Not available")?.read().await;
             let config: &api::ActuatorsConfig = &manager

--- a/backend/libs/autopilot/src/mod.rs
+++ b/backend/libs/autopilot/src/mod.rs
@@ -68,7 +68,7 @@ pub(crate) async fn control_inner(
         Action::ExportLuaScript => {
             let camera_uuid = actuators_control.camera_uuid;
             manager::reboot_outside_apply(
-                async {
+                Box::pin(async {
                     let reload_script = manager::Manager::export_script(&camera_uuid, true).await?;
                     manager::Manager::save_actuators_settings().await?;
                     if reload_script {
@@ -77,9 +77,9 @@ pub(crate) async fn control_inner(
                             .await?;
                     }
                     crate::mavlink::component()?.enable_lua_script(false).await
-                },
+                }),
                 // Export already saved under apply; post-reboot finalize is a no-op.
-                async { Ok(()) },
+                Box::pin(async { Ok(()) }),
             )
             .await?;
 
@@ -233,14 +233,16 @@ pub(crate) async fn control_inner(
             };
 
             manager::reboot_outside_apply(
-                async { manager::Manager::update_config(&camera_uuid, &new_config, false).await },
-                async {
+                Box::pin(async {
+                    manager::Manager::update_config(&camera_uuid, &new_config, false).await
+                }),
+                Box::pin(async {
                     manager::Manager::finalize_config_after_reboot(
                         &camera_uuid,
                         new_config.parameters.as_ref(),
                     )
                     .await
-                },
+                }),
             )
             .await?;
 
@@ -258,14 +260,14 @@ pub(crate) async fn control_inner(
             let camera_uuid = actuators_control.camera_uuid;
             let default_params = api::ActuatorsConfig::from(&CameraActuators::default());
             manager::reboot_outside_apply(
-                async { manager::Manager::reset_config(&camera_uuid).await },
-                async {
+                Box::pin(async { manager::Manager::reset_config(&camera_uuid).await }),
+                Box::pin(async {
                     manager::Manager::finalize_config_after_reboot(
                         &camera_uuid,
                         default_params.parameters.as_ref(),
                     )
                     .await
-                },
+                }),
             )
             .await?;
 


### PR DESCRIPTION
## Summary
Split from the websockets work: **Unlock config apply I/O and fix apply lifecycle**.

Commits in this slice:
- `backend: libs: autopilot: Drop MANAGER lock across config apply I/O`
- `backend: libs: autopilot: Fix apply lifecycle for clear, export, and reboot`
- `backend: libs: autopilot: Box reboot_outside_apply futures to fix Send overflow`

## Stack
- Part **18/24** of the websockets split (all PRs target `master`)
- Depends on https://github.com/bluerobotics/radcam-manager/pull/218 merging first.
- After the previous stack PR merges: rebase this branch onto `master` and `git push --force-with-lease`
- Intermediate slices may show **red CI** (incomplete stack / missing later fixes). That is expected.
- The batch is only done when tip **[#225](https://github.com/bluerobotics/radcam-manager/pull/225)** (`24/24`) is green after the full merge-rebase dance.

## Test plan
- [ ] Custom/default hardware apply, clear, and export complete without deadlocking the watcher
- [ ] Reboot-outside-apply futures stay `Send` (release build / tip CI)
- [ ] After clear/export/reboot, script health / tilt mount type end in the expected post-apply state
