### PR TITLE
websockets 19/24: Add pendingFields and migrate image/base params

### DIFF
--- a/frontend/src/components/BasicSettings.vue
+++ b/frontend/src/components/BasicSettings.vue
@@ -645,6 +645,7 @@ import ExpansiblePanel from './ExpansiblePanel.vue'
 import BlueSelect from './BlueSelect.vue'
 import { type BaseParameterSetting, type VideoParameterSettings, type VideoResolutionValue, BaseAutoWhiteBalanceModeValue, BaseAutoWhiteBalanceSceneValue, type AdvancedParameterSetting, type CameraControl } from '@/bindings/radcam'
 import { backendClient } from '@/utils/backendClient'
+import { createPendingFields } from '@/utils/pendingFields'
 import { useCameraState } from '@/utils/useCameraState'
 import type { ActuatorsConfig, ActuatorsControl, ActuatorsParametersConfig, ActuatorsState, CameraID, MountType, ScriptFunction, ServoChannel } from '@/bindings/autopilot'
 import type { CameraStateEvent } from '@/bindings/radcam_api'
@@ -808,10 +809,7 @@ const actuatorsSetQueued = ref<Record<ActuatorKey, number | null>>({
 })
 /** Bumped on camera switch so in-flight actuator POSTs ignore stale `.finally` cleanup. */
 const actuatorsRequestGeneration = ref(0)
-/** Monotonic seq so only the newest image-param write may apply its response body. */
-let baseParamWriteSeq = 0
-/** Fields with an optimistic write that must not be clobbered by WS/GET. */
-const dirtyBaseParamFields = new Set<keyof BaseParameterSetting>()
+const pendingBase = createPendingFields<keyof BaseParameterSetting, unknown>()
 const correlationToggleInFlight = ref(false)
 const isConfigured = ref<boolean>(false)
 const showWelcomeDialog = ref<boolean>(true)
@@ -877,8 +875,8 @@ watch(
     hasUserEditedVideo.value = false
     hasUnsavedVideoChanges.value = false
     actuatorsRequestGeneration.value += 1
-    baseParamWriteSeq += 1
     inFlightParamWrites.value = 0
+    pendingBase.clear()
     correlationToggleInFlight.value = false
     isConfigured.value = false
     showAdvancedHardware.value = false
@@ -916,7 +914,6 @@ watch(
     actuatorsSetRollback.value = { focus: null, zoom: null, tilt: null }
     actuatorsSetQueued.value = { focus: null, zoom: null, tilt: null }
     actuatorsSetInFlight.value = { focus: false, zoom: false, tilt: false }
-    dirtyBaseParamFields.clear()
   },
 )
 
@@ -1075,10 +1072,9 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
 
   const cameraUuid = props.selectedCameraUuid
   const generation = actuatorsRequestGeneration.value
-  const writeSeq = ++baseParamWriteSeq
   const previous = baseParams.value[param]
+  const { token, epoch } = pendingBase.begin(param, previous, value)
   baseParams.value = { ...baseParams.value, [param]: value }
-  dirtyBaseParamFields.add(param)
   inFlightParamWrites.value++
 
   const payload = {
@@ -1094,13 +1090,17 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
     .then((data) => {
       if (
         props.selectedCameraUuid !== cameraUuid ||
-        generation !== actuatorsRequestGeneration.value ||
-        writeSeq !== baseParamWriteSeq
+        generation !== actuatorsRequestGeneration.value
       ) {
         return
       }
-      baseParams.value = data as BaseParameterSetting
-      dirtyBaseParamFields.clear()
+      const incoming = data as BaseParameterSetting
+      pendingBase.settleSuccess(param, token, epoch, () => {
+        baseParams.value = pendingBase.mergeRemote(incoming, {
+          ...incoming,
+          [param]: value,
+        } as BaseParameterSetting)
+      })
     })
     .catch((error) => {
       const message = `Error sending ${String(param)} control with value '${value}'`
@@ -1111,10 +1111,18 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
       ) {
         return
       }
-      if (baseParams.value[param] === value) {
-        baseParams.value = { ...baseParams.value, [param]: previous }
-      }
-      dirtyBaseParamFields.delete(param)
+      pendingBase.settleFail(
+        param,
+        token,
+        epoch,
+        (attempted) => baseParams.value[param] === attempted,
+        (prev) => {
+          baseParams.value = {
+            ...baseParams.value,
+            [param]: prev as BaseParameterSetting[typeof param],
+          }
+        },
+      )
     })
     .finally(() => {
       if (generation !== actuatorsRequestGeneration.value) return
@@ -1188,17 +1196,10 @@ const applyCameraStateEvent = (body: unknown) => {
     update_video_parameter_values(data.video_parameters as VideoParameterSettings)
   }
   if (data.base_parameters) {
-    const incoming = data.base_parameters as BaseParameterSetting
-    if (dirtyBaseParamFields.size === 0) {
-      baseParams.value = incoming
-    } else {
-      baseParams.value = {
-        ...incoming,
-        ...Object.fromEntries(
-          [...dirtyBaseParamFields].map((key) => [key, baseParams.value[key]]),
-        ),
-      } as BaseParameterSetting
-    }
+    baseParams.value = pendingBase.mergeRemote(
+      data.base_parameters as BaseParameterSetting,
+      baseParams.value,
+    )
   }
 }
 
@@ -1410,7 +1411,6 @@ const getBaseParameters = () => {
 
   const cameraUuid = props.selectedCameraUuid
   const generation = actuatorsRequestGeneration.value
-  const writeSeqAtStart = baseParamWriteSeq
   const payload = {
     camera_uuid: cameraUuid,
     action: "getImageAdjustment",
@@ -1420,14 +1420,14 @@ const getBaseParameters = () => {
     .then(data => {
       if (
         props.selectedCameraUuid !== cameraUuid ||
-        generation !== actuatorsRequestGeneration.value ||
-        writeSeqAtStart !== baseParamWriteSeq ||
-        inFlightParamWrites.value > 0 ||
-        dirtyBaseParamFields.size > 0
+        generation !== actuatorsRequestGeneration.value
       ) {
         return
       }
-      baseParams.value = data as BaseParameterSetting
+      baseParams.value = pendingBase.mergeRemote(
+        data as BaseParameterSetting,
+        baseParams.value,
+      )
       console.log(data)
     })
     .catch(error => {

--- a/frontend/src/components/BasicSettings.vue
+++ b/frontend/src/components/BasicSettings.vue
@@ -645,6 +645,12 @@ import ExpansiblePanel from './ExpansiblePanel.vue'
 import BlueSelect from './BlueSelect.vue'
 import { type BaseParameterSetting, type VideoParameterSettings, type VideoResolutionValue, BaseAutoWhiteBalanceModeValue, BaseAutoWhiteBalanceSceneValue, type AdvancedParameterSetting, type CameraControl } from '@/bindings/radcam'
 import { backendClient } from '@/utils/backendClient'
+import {
+  createActuatorTokenSource,
+  ownsActuatorFlight,
+  shouldRollbackActuatorUi,
+  type ActuatorFlight,
+} from '@/utils/actuatorFlight'
 import { createPendingFields } from '@/utils/pendingFields'
 import { useCameraState } from '@/utils/useCameraState'
 import type { ActuatorsConfig, ActuatorsControl, ActuatorsParametersConfig, ActuatorsState, CameraID, MountType, ScriptFunction, ServoChannel } from '@/bindings/autopilot'
@@ -797,10 +803,11 @@ const armDesiredLatch = (key: ActuatorKey, value: number): void => {
 
 // Coalesce actuator set requests so only one request per actuator can be in-flight, always
 // sending the most recent value (prevents request pile-up).
-const actuatorsSetInFlight = ref<Record<ActuatorKey, boolean>>({
-  focus: false,
-  zoom: false,
-  tilt: false,
+const actuatorTokens = createActuatorTokenSource()
+const actuatorsSetInFlight = ref<Record<ActuatorKey, ActuatorFlight | null>>({
+  focus: null,
+  zoom: null,
+  tilt: null,
 })
 const actuatorsSetQueued = ref<Record<ActuatorKey, number | null>>({
   focus: null,
@@ -913,7 +920,7 @@ watch(
     ;(['focus', 'zoom', 'tilt'] as const).forEach(clearDesiredLatch)
     actuatorsSetRollback.value = { focus: null, zoom: null, tilt: null }
     actuatorsSetQueued.value = { focus: null, zoom: null, tilt: null }
-    actuatorsSetInFlight.value = { focus: false, zoom: false, tilt: false }
+    actuatorsSetInFlight.value = { focus: null, zoom: null, tilt: null }
   },
 )
 
@@ -1304,15 +1311,16 @@ const updateActuatorsConfig = (param: keyof ActuatorsParametersConfig, value: an
 const sendQueuedActuatorState = (param: ActuatorKey, allowWhileDisabled = false): void => {
   if (!props.selectedCameraUuid) return
   if (props.disabled && !allowWhileDisabled) return
-  if (actuatorsSetInFlight.value[param]) return
+  if (actuatorsSetInFlight.value[param] !== null) return
 
   const value = actuatorsSetQueued.value[param]
   if (value === null) return
 
   const cameraUuid = props.selectedCameraUuid
   const generation = actuatorsRequestGeneration.value
+  const token = actuatorTokens.next()
   actuatorsSetQueued.value[param] = null
-  actuatorsSetInFlight.value[param] = true
+  actuatorsSetInFlight.value[param] = { token, value }
 
   const payload: ActuatorsControl = {
     camera_uuid: cameraUuid,
@@ -1326,6 +1334,8 @@ const sendQueuedActuatorState = (param: ActuatorKey, allowWhileDisabled = false)
       const message = `Error updating ${param}`
       console.log(message, error.message)
       if (generation !== actuatorsRequestGeneration.value) return
+      if (!ownsActuatorFlight(actuatorsSetInFlight.value[param], token)) return
+
       // Failed command will never match SERVO — drop the latch for this value.
       if (
         desiredActuatorsState.value[param] !== null &&
@@ -1333,13 +1343,17 @@ const sendQueuedActuatorState = (param: ActuatorKey, allowWhileDisabled = false)
       ) {
         clearDesiredLatch(param)
       }
-      // Roll back optimistic UI if nothing newer is queued/desired.
+      // Roll back optimistic UI if this flight still owns the slot and nothing newer is pending.
       if (
-        actuatorsSetQueued.value[param] === null &&
-        desiredActuatorsState.value[param] === null &&
-        actuatorsState.value[param] !== null &&
-        approxEqual(actuatorsState.value[param]!, value, param) &&
-        actuatorsSetRollback.value[param] !== null
+        shouldRollbackActuatorUi({
+          ownsFlight: true,
+          queued: actuatorsSetQueued.value[param],
+          desired: desiredActuatorsState.value[param],
+          ui: actuatorsState.value[param],
+          attempted: value,
+          rollback: actuatorsSetRollback.value[param],
+          valuesMatch: (a, b) => approxEqual(a, b, param),
+        })
       ) {
         actuatorsState.value[param] = actuatorsSetRollback.value[param]
       }
@@ -1349,8 +1363,11 @@ const sendQueuedActuatorState = (param: ActuatorKey, allowWhileDisabled = false)
       if (generation !== actuatorsRequestGeneration.value) {
         return
       }
+      if (!ownsActuatorFlight(actuatorsSetInFlight.value[param], token)) {
+        return
+      }
 
-      actuatorsSetInFlight.value[param] = false
+      actuatorsSetInFlight.value[param] = null
 
       // If a newer value was queued while this request was in-flight, send it now
       // even if the UI is disabled (loading/reboot) so the drain cannot strand.
@@ -1370,7 +1387,7 @@ const updateActuatorsState = (param: keyof ActuatorsState, value: number) => {
   // Capture pre-gesture value once so a failed POST can roll back.
   if (
     actuatorsSetQueued.value[key] === null &&
-    !actuatorsSetInFlight.value[key]
+    actuatorsSetInFlight.value[key] === null
   ) {
     actuatorsSetRollback.value[key] = actuatorsState.value[key]
   }

--- a/frontend/src/components/ImageTab.vue
+++ b/frontend/src/components/ImageTab.vue
@@ -730,6 +730,7 @@ import {
 import { enumToOptions } from '@/utils/enumUtils'
 import { backendClient } from '@/utils/backendClient'
 import { useCameraState } from '@/utils/useCameraState'
+import { createPendingFields } from '@/utils/pendingFields'
 import { ref, toRef, watch } from 'vue'
 
 const props = defineProps<{
@@ -851,12 +852,8 @@ const antiFlickerOptions = enumToOptions(AdvancedDisplayAntiflickerValue)
 const inFlightBaseWrites = ref(0)
 const inFlightAdvancedWrites = ref(0)
 const imageRequestGeneration = ref(0)
-/** Monotonic seq so only the newest write/restore may apply its response body. */
-let baseWriteSeq = 0
-let advancedWriteSeq = 0
-/** Fields with an optimistic write that must not be clobbered by WS/GET. */
-const dirtyBaseFields = new Set<keyof BaseParameterSetting>()
-const dirtyAdvancedFields = new Set<keyof AdvancedParameterSetting>()
+const pendingBase = createPendingFields<keyof BaseParameterSetting, unknown>()
+const pendingAdvanced = createPendingFields<keyof AdvancedParameterSetting, unknown>()
 
 const applyCameraStateEvent = (body: unknown) => {
   if (!props.selectedCameraUuid) return
@@ -866,30 +863,16 @@ const applyCameraStateEvent = (body: unknown) => {
   if (data.camera_uuid !== props.selectedCameraUuid) return
 
   if (data.base_parameters) {
-    const incoming = data.base_parameters as BaseParameterSetting
-    if (dirtyBaseFields.size === 0) {
-      baseParams.value = incoming
-    } else {
-      baseParams.value = {
-        ...incoming,
-        ...Object.fromEntries(
-          [...dirtyBaseFields].map((key) => [key, baseParams.value[key]]),
-        ),
-      } as BaseParameterSetting
-    }
+    baseParams.value = pendingBase.mergeRemote(
+      data.base_parameters as BaseParameterSetting,
+      baseParams.value,
+    )
   }
   if (data.advanced_parameters) {
-    const incoming = data.advanced_parameters as AdvancedParameterSetting
-    if (dirtyAdvancedFields.size === 0) {
-      advancedParams.value = incoming
-    } else {
-      advancedParams.value = {
-        ...incoming,
-        ...Object.fromEntries(
-          [...dirtyAdvancedFields].map((key) => [key, advancedParams.value[key]]),
-        ),
-      } as AdvancedParameterSetting
-    }
+    advancedParams.value = pendingAdvanced.mergeRemote(
+      data.advanced_parameters as AdvancedParameterSetting,
+      advancedParams.value,
+    )
   }
 }
 
@@ -901,10 +884,8 @@ watch(
     imageRequestGeneration.value += 1
     inFlightBaseWrites.value = 0
     inFlightAdvancedWrites.value = 0
-    baseWriteSeq += 1
-    advancedWriteSeq += 1
-    dirtyBaseFields.clear()
-    dirtyAdvancedFields.clear()
+    pendingBase.clear()
+    pendingAdvanced.clear()
     processingWhiteBalance.value = false
     processingBaseRestore.value = false
     processingAdvancedRestore.value = false
@@ -919,10 +900,9 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
 
   const cameraUuid = props.selectedCameraUuid
   const generation = imageRequestGeneration.value
-  const writeSeq = ++baseWriteSeq
   const previous = baseParams.value[param]
+  const { token, epoch } = pendingBase.begin(param, previous, value)
   baseParams.value = { ...baseParams.value, [param]: value }
-  dirtyBaseFields.add(param)
   inFlightBaseWrites.value++
 
   const payload = {
@@ -939,13 +919,17 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
     .then(data => {
       if (
         props.selectedCameraUuid !== cameraUuid ||
-        generation !== imageRequestGeneration.value ||
-        writeSeq !== baseWriteSeq
+        generation !== imageRequestGeneration.value
       ) {
         return
       }
-      baseParams.value = data as BaseParameterSetting
-      dirtyBaseFields.clear()
+      const incoming = data as BaseParameterSetting
+      pendingBase.settleSuccess(param, token, epoch, () => {
+        baseParams.value = pendingBase.mergeRemote(incoming, {
+          ...incoming,
+          [param]: value,
+        } as BaseParameterSetting)
+      })
     })
     .catch(error => {
       console.error(`Error sending ${String(param)} control with value '${value}':`, error.message)
@@ -955,11 +939,15 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
       ) {
         return
       }
-      // Revert this field even if a newer writeSeq superseded us (other fields).
-      if (baseParams.value[param] === value) {
-        baseParams.value = { ...baseParams.value, [param]: previous }
-      }
-      dirtyBaseFields.delete(param)
+      pendingBase.settleFail(
+        param,
+        token,
+        epoch,
+        (attempted) => baseParams.value[param] === attempted,
+        (prev) => {
+          baseParams.value = { ...baseParams.value, [param]: prev as BaseParameterSetting[typeof param] }
+        },
+      )
     })
     .finally(() => {
       if (generation !== imageRequestGeneration.value) return
@@ -974,7 +962,6 @@ const getBaseParameters = () => {
 
   const cameraUuid = props.selectedCameraUuid
   const generation = imageRequestGeneration.value
-  const writeSeqAtStart = baseWriteSeq
   const payload = {
     camera_uuid: cameraUuid,
     action: "getImageAdjustment",
@@ -984,14 +971,14 @@ const getBaseParameters = () => {
     .then(data => {
       if (
         props.selectedCameraUuid !== cameraUuid ||
-        generation !== imageRequestGeneration.value ||
-        writeSeqAtStart !== baseWriteSeq ||
-        inFlightBaseWrites.value > 0 ||
-        dirtyBaseFields.size > 0
+        generation !== imageRequestGeneration.value
       ) {
         return
       }
-      baseParams.value = data as BaseParameterSetting
+      baseParams.value = pendingBase.mergeRemote(
+        data as BaseParameterSetting,
+        baseParams.value,
+      )
       console.log(data)
     })
     .catch(error => {
@@ -1039,9 +1026,8 @@ const doRestoreBase = async () => {
 
   const cameraUuid = props.selectedCameraUuid
   const generation = imageRequestGeneration.value
-  const writeSeq = ++baseWriteSeq
+  pendingBase.beginRestore()
   inFlightBaseWrites.value++
-  dirtyBaseFields.clear()
   const payload: CameraControl = {
     camera_uuid: cameraUuid,
     action: "setImageAdjustment",
@@ -1055,13 +1041,11 @@ const doRestoreBase = async () => {
     .then(data => {
       if (
         props.selectedCameraUuid !== cameraUuid ||
-        generation !== imageRequestGeneration.value ||
-        writeSeq !== baseWriteSeq
+        generation !== imageRequestGeneration.value
       ) {
         return
       }
       baseParams.value = data as BaseParameterSetting
-      dirtyBaseFields.clear()
     })
     .catch(error => {
       console.error("Error sending base image restore control:", error.message)
@@ -1079,10 +1063,9 @@ const updateAdvancedParam = (param: keyof AdvancedParameterSetting, value: any) 
 
   const cameraUuid = props.selectedCameraUuid
   const generation = imageRequestGeneration.value
-  const writeSeq = ++advancedWriteSeq
   const previous = advancedParams.value[param]
+  const { token, epoch } = pendingAdvanced.begin(param, previous, value)
   advancedParams.value = { ...advancedParams.value, [param]: value }
-  dirtyAdvancedFields.add(param)
   inFlightAdvancedWrites.value++
 
   const payload: CameraControl = {
@@ -1095,13 +1078,17 @@ const updateAdvancedParam = (param: keyof AdvancedParameterSetting, value: any) 
     .then(data => {
       if (
         props.selectedCameraUuid !== cameraUuid ||
-        generation !== imageRequestGeneration.value ||
-        writeSeq !== advancedWriteSeq
+        generation !== imageRequestGeneration.value
       ) {
         return
       }
-      advancedParams.value = data as AdvancedParameterSetting
-      dirtyAdvancedFields.clear()
+      const incoming = data as AdvancedParameterSetting
+      pendingAdvanced.settleSuccess(param, token, epoch, () => {
+        advancedParams.value = pendingAdvanced.mergeRemote(incoming, {
+          ...incoming,
+          [param]: value,
+        } as AdvancedParameterSetting)
+      })
     })
     .catch(error => {
       console.error(`Error updating ${param}:`, error.message)
@@ -1111,10 +1098,18 @@ const updateAdvancedParam = (param: keyof AdvancedParameterSetting, value: any) 
       ) {
         return
       }
-      if (advancedParams.value[param] === value) {
-        advancedParams.value = { ...advancedParams.value, [param]: previous }
-      }
-      dirtyAdvancedFields.delete(param)
+      pendingAdvanced.settleFail(
+        param,
+        token,
+        epoch,
+        (attempted) => advancedParams.value[param] === attempted,
+        (prev) => {
+          advancedParams.value = {
+            ...advancedParams.value,
+            [param]: prev as AdvancedParameterSetting[typeof param],
+          }
+        },
+      )
     })
     .finally(() => {
       if (generation !== imageRequestGeneration.value) return
@@ -1129,9 +1124,8 @@ const doRestoreAdvanced = async () => {
 
   const cameraUuid = props.selectedCameraUuid
   const generation = imageRequestGeneration.value
-  const writeSeq = ++advancedWriteSeq
+  pendingAdvanced.beginRestore()
   inFlightAdvancedWrites.value++
-  dirtyAdvancedFields.clear()
   const payload: CameraControl = {
     camera_uuid: cameraUuid,
     action: "setImageAdjustmentEx",
@@ -1142,13 +1136,11 @@ const doRestoreAdvanced = async () => {
     .then(data => {
       if (
         props.selectedCameraUuid !== cameraUuid ||
-        generation !== imageRequestGeneration.value ||
-        writeSeq !== advancedWriteSeq
+        generation !== imageRequestGeneration.value
       ) {
         return
       }
       advancedParams.value = data as AdvancedParameterSetting
-      dirtyAdvancedFields.clear()
     })
     .catch(error => {
       console.error("Error restoring advanced parameters:", error.message)

--- a/frontend/src/components/StreamsTab.vue
+++ b/frontend/src/components/StreamsTab.vue
@@ -258,8 +258,11 @@ const applyCameraStateEvent = (body: unknown) => {
   if (!data.video_parameters) return
   if (hasUserEditedVideo.value) return
   if (awaitingRestartHydrate) {
-    // First post-restart video snapshot — accept and clear the latch.
-    update_video_parameter_values(data.video_parameters as VideoParameterSettings)
+    const settings = data.video_parameters as VideoParameterSettings
+    const currentChannel = selectedVideoParameters.value.channel ?? VideoChannelValue.MainStream
+    if (settings.channel != null && settings.channel !== currentChannel) return
+    // First matching post-restart video snapshot — accept and clear the latch.
+    update_video_parameter_values(settings)
     clearRestartHydrateLatch()
     return
   }

--- a/frontend/src/utils/actuatorFlight.selfcheck.ts
+++ b/frontend/src/utils/actuatorFlight.selfcheck.ts
@@ -82,7 +82,3 @@ export function runActuatorFlightSelfCheck(): void {
 
   console.log('actuatorFlight self-check ok')
 }
-
-if (typeof process !== 'undefined' && process.env?.NODE_ENV === 'test') {
-  runActuatorFlightSelfCheck()
-}

--- a/frontend/src/utils/actuatorFlight.selfcheck.ts
+++ b/frontend/src/utils/actuatorFlight.selfcheck.ts
@@ -1,0 +1,88 @@
+import {
+  createActuatorTokenSource,
+  ownsActuatorFlight,
+  shouldRollbackActuatorUi,
+  type ActuatorFlight,
+} from './actuatorFlight'
+
+/** Assert-based self-check for actuator flight tokens (no test framework). */
+export function runActuatorFlightSelfCheck(): void {
+  const tokens = createActuatorTokenSource()
+  const t1 = tokens.next()
+  const t2 = tokens.next()
+  const flight: ActuatorFlight = { token: t1, value: 80 }
+
+  if (!ownsActuatorFlight(flight, t1)) {
+    throw new Error('actuatorFlight: owner should match token')
+  }
+  if (ownsActuatorFlight(flight, t2)) {
+    throw new Error('actuatorFlight: superseded token must not own flight')
+  }
+  if (ownsActuatorFlight(null, t1)) {
+    throw new Error('actuatorFlight: null flight must not own')
+  }
+
+  const match = (a: number, b: number) => Math.abs(a - b) <= 0.5
+
+  if (
+    !shouldRollbackActuatorUi({
+      ownsFlight: true,
+      queued: null,
+      desired: null,
+      ui: 80,
+      attempted: 80,
+      rollback: 50,
+      valuesMatch: match,
+    })
+  ) {
+    throw new Error('actuatorFlight: expected rollback when attempt still on UI')
+  }
+
+  if (
+    shouldRollbackActuatorUi({
+      ownsFlight: false,
+      queued: null,
+      desired: null,
+      ui: 80,
+      attempted: 80,
+      rollback: 50,
+      valuesMatch: match,
+    })
+  ) {
+    throw new Error('actuatorFlight: superseded flight must not rollback')
+  }
+
+  if (
+    shouldRollbackActuatorUi({
+      ownsFlight: true,
+      queued: 90,
+      desired: null,
+      ui: 80,
+      attempted: 80,
+      rollback: 50,
+      valuesMatch: match,
+    })
+  ) {
+    throw new Error('actuatorFlight: queued newer value must block rollback')
+  }
+
+  if (
+    shouldRollbackActuatorUi({
+      ownsFlight: true,
+      queued: null,
+      desired: 90,
+      ui: 90,
+      attempted: 80,
+      rollback: 50,
+      valuesMatch: match,
+    })
+  ) {
+    throw new Error('actuatorFlight: newer desired must block rollback')
+  }
+
+  console.log('actuatorFlight self-check ok')
+}
+
+if (typeof process !== 'undefined' && process.env?.NODE_ENV === 'test') {
+  runActuatorFlightSelfCheck()
+}

--- a/frontend/src/utils/actuatorFlight.ts
+++ b/frontend/src/utils/actuatorFlight.ts
@@ -1,0 +1,48 @@
+/**
+ * In-flight ownership for coalesced actuator set POSTs.
+ *
+ * Only the request whose token still matches the flight slot may clear the
+ * slot, drain the queue, or roll back optimistic UI on failure.
+ */
+
+export type ActuatorFlight = {
+  token: number
+  value: number
+}
+
+export function createActuatorTokenSource() {
+  let next = 1
+  return {
+    next(): number {
+      return next++
+    },
+  }
+}
+
+export function ownsActuatorFlight(
+  flight: ActuatorFlight | null | undefined,
+  token: number,
+): boolean {
+  return flight != null && flight.token === token
+}
+
+/**
+ * Whether a failed POST should restore the pre-gesture UI value.
+ * Caller should clear the desired latch for `attempted` before calling when
+ * that latch still targets this attempt.
+ */
+export function shouldRollbackActuatorUi(args: {
+  ownsFlight: boolean
+  queued: number | null
+  desired: number | null
+  ui: number | null
+  attempted: number
+  rollback: number | null
+  valuesMatch: (a: number, b: number) => boolean
+}): boolean {
+  if (!args.ownsFlight) return false
+  if (args.queued !== null) return false
+  if (args.desired !== null) return false
+  if (args.rollback === null || args.ui === null) return false
+  return args.valuesMatch(args.ui, args.attempted)
+}

--- a/frontend/src/utils/backendClient.ts
+++ b/frontend/src/utils/backendClient.ts
@@ -220,7 +220,8 @@ class BackendClient {
         this.lastMessageAt = Date.now()
         this.setConnectionState('connected')
         this.startStaleCheck()
-        // Re-subscribe immediately on reconnect (do not wait for camera/list).
+        // Cap is per-connection — clear before re-subscribe on a new socket.
+        this.subscribeBlocked = false
         if (this.subscribedCameraUuid) {
           this.queueSubscribe(this.subscribedCameraUuid)
         }
@@ -242,6 +243,7 @@ class BackendClient {
         this.setConnectionState('disconnected')
         // Force list-driven re-subscribe after reconnect — prior state may be gone.
         this.hasCameraState = false
+        this.subscribeBlocked = false
         this.rejectAllPending(new Error('WebSocket closed'))
 
         if (!settled) {
@@ -480,13 +482,13 @@ class BackendClient {
   /** Re-push subscribe for the active camera without changing refcounts (tab remount). */
   refreshCameraSubscription(): void {
     if (this.subscribedCameraUuid) {
-      // Do not clear subscribeBlocked — tab remount must not retry past camera_cap.
       this.queueSubscribe(this.subscribedCameraUuid)
     }
   }
 
   /** Collapse same-uuid subscribes issued in the same tick into one wire frame. */
   private queueSubscribe(cameraUuid: string): void {
+    if (this.subscribeBlocked) return
     this.pendingSubscribe = cameraUuid
     if (this.subscribeQueued) return
     this.subscribeQueued = true
@@ -495,7 +497,7 @@ class BackendClient {
       const pending = this.pendingSubscribe
       this.pendingSubscribe = null
       // Skip if unsubscribe cleared the active uuid in the same tick.
-      if (pending && pending === this.subscribedCameraUuid) {
+      if (pending && pending === this.subscribedCameraUuid && !this.subscribeBlocked) {
         this.sendCameraSubscription('subscribe', pending)
       }
     })

--- a/frontend/src/utils/pendingFields.selfcheck.ts
+++ b/frontend/src/utils/pendingFields.selfcheck.ts
@@ -45,7 +45,3 @@ export function runPendingFieldsSelfCheck(): void {
 
   console.log('pendingFields self-check ok')
 }
-
-if (typeof process !== 'undefined' && process.env?.NODE_ENV === 'test') {
-  runPendingFieldsSelfCheck()
-}

--- a/frontend/src/utils/pendingFields.selfcheck.ts
+++ b/frontend/src/utils/pendingFields.selfcheck.ts
@@ -1,0 +1,51 @@
+import { createPendingFields } from './pendingFields'
+
+/** Assert-based self-check for pending-field ownership (no test framework). */
+export function runPendingFieldsSelfCheck(): void {
+  const pending = createPendingFields<'a' | 'b', number>()
+
+  const a1 = pending.begin('a', 0, 1)
+  const b1 = pending.begin('b', 10, 11)
+
+  // Fail of A must not drop B's pending.
+  pending.settleFail(
+    'a',
+    a1.token,
+    a1.epoch,
+    () => true,
+    () => {},
+  )
+  if (!pending.isPendingKey('b')) {
+    throw new Error('pendingFields: fail of A cleared B')
+  }
+
+  // Success of B must not clear a re-begun A.
+  const a2 = pending.begin('a', 0, 2)
+  pending.settleSuccess('b', b1.token, b1.epoch, () => {})
+  if (!pending.isPendingKey('a')) {
+    throw new Error('pendingFields: success of B cleared A')
+  }
+
+  const merged = pending.mergeRemote({ a: 99, b: 99 }, { a: 2, b: 11 })
+  if (merged.a !== 2) {
+    throw new Error('pendingFields: mergeRemote overwrote pending A')
+  }
+  if (merged.b !== 99) {
+    throw new Error('pendingFields: mergeRemote kept settled B local')
+  }
+
+  pending.beginRestore()
+  if (
+    pending.settleSuccess('a', a2.token, a2.epoch, () => {
+      throw new Error('should not apply')
+    })
+  ) {
+    throw new Error('pendingFields: restore epoch did not reject late settle')
+  }
+
+  console.log('pendingFields self-check ok')
+}
+
+if (typeof process !== 'undefined' && process.env?.NODE_ENV === 'test') {
+  runPendingFieldsSelfCheck()
+}

--- a/frontend/src/utils/pendingFields.ts
+++ b/frontend/src/utils/pendingFields.ts
@@ -1,0 +1,99 @@
+/**
+ * Per-field optimistic write ownership.
+ *
+ * Each in-flight field write gets a token. Success/fail only settles that token.
+ * Remote merges never overwrite pending keys. Restore bumps epoch so late
+ * per-field settles are ignored.
+ */
+export type PendingEntry<V> = {
+  token: number
+  previous: V
+  value: V
+}
+
+export function createPendingFields<K extends string, V>() {
+  const pending = new Map<K, PendingEntry<V>>()
+  let nextToken = 1
+  let epoch = 0
+
+  const begin = (key: K, previous: V, value: V): { token: number; epoch: number } => {
+    const token = nextToken++
+    pending.set(key, { token, previous, value })
+    return { token, epoch }
+  }
+
+  const settleSuccess = (
+    key: K,
+    token: number,
+    settleEpoch: number,
+    applySettled: (previousLocal: V) => void,
+  ): boolean => {
+    if (settleEpoch !== epoch) return false
+    const entry = pending.get(key)
+    if (!entry || entry.token !== token) return false
+    pending.delete(key)
+    applySettled(entry.value)
+    return true
+  }
+
+  const settleFail = (
+    key: K,
+    token: number,
+    settleEpoch: number,
+    currentEqualsAttempted: (attempted: V) => boolean,
+    revert: (previous: V) => void,
+  ): boolean => {
+    if (settleEpoch !== epoch) return false
+    const entry = pending.get(key)
+    if (!entry || entry.token !== token) return false
+    pending.delete(key)
+    if (currentEqualsAttempted(entry.value)) {
+      revert(entry.previous)
+    }
+    return true
+  }
+
+  const mergeRemote = <T extends Record<string, unknown>>(
+    incoming: T,
+    local: T,
+  ): T => {
+    if (pending.size === 0) return incoming
+    const merged = { ...incoming }
+    for (const key of pending.keys()) {
+      if (key in local) {
+        ;(merged as Record<string, unknown>)[key] = local[key as keyof T]
+      }
+    }
+    return merged
+  }
+
+  /** Whole-object restore: invalidate all outstanding per-field settles. */
+  const beginRestore = (): number => {
+    epoch += 1
+    pending.clear()
+    return epoch
+  }
+
+  const clear = (): void => {
+    epoch += 1
+    pending.clear()
+  }
+
+  const hasPending = (): boolean => pending.size > 0
+
+  const isPendingKey = (key: K): boolean => pending.has(key)
+
+  return {
+    begin,
+    settleSuccess,
+    settleFail,
+    mergeRemote,
+    beginRestore,
+    clear,
+    hasPending,
+    isPendingKey,
+    get epoch() {
+      return epoch
+    },
+  }
+}


### PR DESCRIPTION
## Summary
Split from the websockets work: **Add pendingFields and migrate image/base params**.

Commits in this slice:
- `frontend: Add usePendingFields and migrate ImageTab image params`
- `frontend: Migrate BasicSettings base params to pendingFields`
- `frontend: Gate actuator rollback on in-flight tokens`
- `frontend: Drop process.env auto-run from self-checks`

## Stack
- Part **19/24** of the websockets split (all PRs target `master`)
- Depends on https://github.com/bluerobotics/radcam-manager/pull/219 merging first.
- After the previous stack PR merges: rebase this branch onto `master` and `git push --force-with-lease`
- Intermediate slices may show **red CI** (incomplete stack / missing later fixes). That is expected.
- The batch is only done when tip **[#225](https://github.com/bluerobotics/radcam-manager/pull/225)** (`24/24`) is green after the full merge-rebase dance.

## Test plan
- [ ] ImageTab / BasicSettings base fields keep optimistic values until backend confirms or fails
- [ ] Camera switch clears pending ownership so the new camera is not stuck on old edits
- [ ] Self-checks for pendingFields still run in the intended entrypoints (not via `process.env` auto-run)
