### PR TITLE
websockets 20/24: pendingFields settle, Streams hydrate, actuator rollback

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview",
     "build-only": "vite build",
     "type-check": "vue-tsc --build --force",
+    "selfcheck": "npx --yes tsx src/utils/runSelfChecks.ts",
     "lint": "eslint . --fix"
   },
   "dependencies": {

--- a/frontend/src/components/BasicSettings.vue
+++ b/frontend/src/components/BasicSettings.vue
@@ -740,7 +740,6 @@ const currentFocusAndZoomParams = ref<ActuatorsParametersConfig>({
 const selectedVideoResolution = ref<VideoResolutionValue | null>(null)
 const selectedVideoBitrate = ref<number | null>(null)
 const hasUserEditedVideo = ref<boolean>(false)
-const inFlightParamWrites = ref(0)
 const selectedVideoParameters = ref<VideoParameterSettings>({})
 const downloadedVideoParameters = ref<VideoParameterSettings>({})
 const actuatorsState = ref<ActuatorsState>({
@@ -817,7 +816,8 @@ const actuatorsSetQueued = ref<Record<ActuatorKey, number | null>>({
 /** Bumped on camera switch so in-flight actuator POSTs ignore stale `.finally` cleanup. */
 const actuatorsRequestGeneration = ref(0)
 const pendingBase = createPendingFields<keyof BaseParameterSetting, unknown>()
-const correlationToggleInFlight = ref(false)
+const correlationLatch = ref<{ token: number; value: boolean | null } | null>(null)
+let nextCorrelationToken = 1
 const isConfigured = ref<boolean>(false)
 const showWelcomeDialog = ref<boolean>(true)
 const showAdvancedHardware = ref(false)
@@ -882,9 +882,8 @@ watch(
     hasUserEditedVideo.value = false
     hasUnsavedVideoChanges.value = false
     actuatorsRequestGeneration.value += 1
-    inFlightParamWrites.value = 0
     pendingBase.clear()
-    correlationToggleInFlight.value = false
+    correlationLatch.value = null
     isConfigured.value = false
     showAdvancedHardware.value = false
     processingWhiteBalance.value = false
@@ -1082,7 +1081,6 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
   const previous = baseParams.value[param]
   const { token, epoch } = pendingBase.begin(param, previous, value)
   baseParams.value = { ...baseParams.value, [param]: value }
-  inFlightParamWrites.value++
 
   const payload = {
     camera_uuid: cameraUuid,
@@ -1103,10 +1101,7 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
       }
       const incoming = data as BaseParameterSetting
       pendingBase.settleSuccess(param, token, epoch, () => {
-        baseParams.value = pendingBase.mergeRemote(incoming, {
-          ...incoming,
-          [param]: value,
-        } as BaseParameterSetting)
+        baseParams.value = pendingBase.mergeRemote(incoming)
       })
     })
     .catch((error) => {
@@ -1131,10 +1126,16 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
         },
       )
     })
-    .finally(() => {
-      if (generation !== actuatorsRequestGeneration.value) return
-      inFlightParamWrites.value = Math.max(0, inFlightParamWrites.value - 1)
-    })
+}
+
+const applyConfigParameters = (newParams: ActuatorsParametersConfig): void => {
+  const latch = correlationLatch.value
+  currentFocusAndZoomParams.value = latch
+    ? {
+        ...newParams,
+        enable_focus_and_zoom_correlation: latch.value,
+      }
+    : { ...newParams }
 }
 
 const applyActuatorsConfig = (data: ActuatorsConfig) => {
@@ -1143,9 +1144,7 @@ const applyActuatorsConfig = (data: ActuatorsConfig) => {
     if (intendedFocusAndZoomParams.value.camera_id === null) {
       intendedFocusAndZoomParams.value = { ...newParams }
     }
-    if (!correlationToggleInFlight.value) {
-      currentFocusAndZoomParams.value = { ...newParams }
-    }
+    applyConfigParameters(newParams)
   } else {
     console.warn("Received null 'parameters' from response:", data)
   }
@@ -1205,7 +1204,6 @@ const applyCameraStateEvent = (body: unknown) => {
   if (data.base_parameters) {
     baseParams.value = pendingBase.mergeRemote(
       data.base_parameters as BaseParameterSetting,
-      baseParams.value,
     )
   }
 }
@@ -1251,10 +1249,12 @@ const updateActuatorsConfig = (param: keyof ActuatorsParametersConfig, value: an
     param === 'enable_focus_and_zoom_correlation'
       ? currentFocusAndZoomParams.value.enable_focus_and_zoom_correlation
       : null
+  let correlationToken: number | null = null
 
   if (param === 'enable_focus_and_zoom_correlation') {
-    if (correlationToggleInFlight.value) return
-    correlationToggleInFlight.value = true
+    if (correlationLatch.value !== null) return
+    correlationToken = nextCorrelationToken++
+    correlationLatch.value = { token: correlationToken, value }
     currentFocusAndZoomParams.value = {
       ...currentFocusAndZoomParams.value,
       enable_focus_and_zoom_correlation: value,
@@ -1278,7 +1278,7 @@ const updateActuatorsConfig = (param: keyof ActuatorsParametersConfig, value: an
       }
       const newParams = (data as ActuatorsConfig)?.parameters
       if (newParams) {
-        currentFocusAndZoomParams.value = { ...newParams }
+        applyConfigParameters(newParams)
       } else {
         console.warn("Received null 'parameters' from response:", data)
       }
@@ -1287,8 +1287,11 @@ const updateActuatorsConfig = (param: keyof ActuatorsParametersConfig, value: an
       if (
         param === 'enable_focus_and_zoom_correlation' &&
         props.selectedCameraUuid === cameraUuid &&
-        generation === actuatorsRequestGeneration.value
+        generation === actuatorsRequestGeneration.value &&
+        correlationToken !== null &&
+        correlationLatch.value?.token === correlationToken
       ) {
+        correlationLatch.value = null
         currentFocusAndZoomParams.value = {
           ...currentFocusAndZoomParams.value,
           enable_focus_and_zoom_correlation: previousCorrelation,
@@ -1299,10 +1302,11 @@ const updateActuatorsConfig = (param: keyof ActuatorsParametersConfig, value: an
     })
     .finally(() => {
       if (
-        param === 'enable_focus_and_zoom_correlation' &&
-        generation === actuatorsRequestGeneration.value
+        correlationToken !== null &&
+        generation === actuatorsRequestGeneration.value &&
+        correlationLatch.value?.token === correlationToken
       ) {
-        correlationToggleInFlight.value = false
+        correlationLatch.value = null
       }
     })
 }
@@ -1336,10 +1340,11 @@ const sendQueuedActuatorState = (param: ActuatorKey, allowWhileDisabled = false)
       if (generation !== actuatorsRequestGeneration.value) return
       if (!ownsActuatorFlight(actuatorsSetInFlight.value[param], token)) return
 
+      const desiredBeforeClear = desiredActuatorsState.value[param]
       // Failed command will never match SERVO — drop the latch for this value.
       if (
-        desiredActuatorsState.value[param] !== null &&
-        approxEqual(desiredActuatorsState.value[param]!, value, param)
+        desiredBeforeClear !== null &&
+        approxEqual(desiredBeforeClear, value, param)
       ) {
         clearDesiredLatch(param)
       }
@@ -1348,7 +1353,7 @@ const sendQueuedActuatorState = (param: ActuatorKey, allowWhileDisabled = false)
         shouldRollbackActuatorUi({
           ownsFlight: true,
           queued: actuatorsSetQueued.value[param],
-          desired: desiredActuatorsState.value[param],
+          desiredBeforeClear,
           ui: actuatorsState.value[param],
           attempted: value,
           rollback: actuatorsSetRollback.value[param],
@@ -1443,7 +1448,6 @@ const getBaseParameters = () => {
       }
       baseParams.value = pendingBase.mergeRemote(
         data as BaseParameterSetting,
-        baseParams.value,
       )
       console.log(data)
     })
@@ -1458,6 +1462,7 @@ const updateVideoParameters = async (
   if (!props.selectedCameraUuid || props.disabled) return
 
   const cameraUuid = props.selectedCameraUuid
+  const generation = actuatorsRequestGeneration.value
   const payload = {
     camera_uuid: cameraUuid,
     action: 'setVencConf',
@@ -1466,7 +1471,12 @@ const updateVideoParameters = async (
 
   try {
     const data = await backendClient.request('POST', '/camera/control', payload)
-    if (props.selectedCameraUuid !== cameraUuid) return
+    if (
+      props.selectedCameraUuid !== cameraUuid ||
+      generation !== actuatorsRequestGeneration.value
+    ) {
+      return
+    }
     const settings = data as VideoParameterSettings
     update_video_parameter_values(settings)
   } catch (error) {
@@ -1708,7 +1718,7 @@ const saveHardwareSetup = async (): Promise<void> => {
 
       const newParams = (data as ActuatorsConfig)?.parameters
       if (newParams) {
-        currentFocusAndZoomParams.value = { ...newParams }
+        applyConfigParameters(newParams)
         intendedFocusAndZoomParams.value = { ...newParams }
       }
     })
@@ -1741,7 +1751,7 @@ const resetToRecommendedDefaults = async (): Promise<void> => {
 
       const newParams = (data as ActuatorsConfig)?.parameters
       if (newParams) {
-        currentFocusAndZoomParams.value = { ...newParams }
+        applyConfigParameters(newParams)
         intendedFocusAndZoomParams.value = { ...newParams }
       }
     })

--- a/frontend/src/components/ImageTab.vue
+++ b/frontend/src/components/ImageTab.vue
@@ -849,8 +849,6 @@ const noiseReductionOptions = enumToOptions(AdvancedDisplayNoiseReductionValue)
 const _2dNrLevelOptions = enumToOptions(AdvancedDisplay2dNrLevelValue)
 const antiFlickerOptions = enumToOptions(AdvancedDisplayAntiflickerValue)
 
-const inFlightBaseWrites = ref(0)
-const inFlightAdvancedWrites = ref(0)
 const imageRequestGeneration = ref(0)
 const pendingBase = createPendingFields<keyof BaseParameterSetting, unknown>()
 const pendingAdvanced = createPendingFields<keyof AdvancedParameterSetting, unknown>()
@@ -865,13 +863,11 @@ const applyCameraStateEvent = (body: unknown) => {
   if (data.base_parameters) {
     baseParams.value = pendingBase.mergeRemote(
       data.base_parameters as BaseParameterSetting,
-      baseParams.value,
     )
   }
   if (data.advanced_parameters) {
     advancedParams.value = pendingAdvanced.mergeRemote(
       data.advanced_parameters as AdvancedParameterSetting,
-      advancedParams.value,
     )
   }
 }
@@ -882,8 +878,6 @@ watch(
   () => props.selectedCameraUuid,
   () => {
     imageRequestGeneration.value += 1
-    inFlightBaseWrites.value = 0
-    inFlightAdvancedWrites.value = 0
     pendingBase.clear()
     pendingAdvanced.clear()
     processingWhiteBalance.value = false
@@ -903,7 +897,6 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
   const previous = baseParams.value[param]
   const { token, epoch } = pendingBase.begin(param, previous, value)
   baseParams.value = { ...baseParams.value, [param]: value }
-  inFlightBaseWrites.value++
 
   const payload = {
     camera_uuid: cameraUuid,
@@ -925,10 +918,7 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
       }
       const incoming = data as BaseParameterSetting
       pendingBase.settleSuccess(param, token, epoch, () => {
-        baseParams.value = pendingBase.mergeRemote(incoming, {
-          ...incoming,
-          [param]: value,
-        } as BaseParameterSetting)
+        baseParams.value = pendingBase.mergeRemote(incoming)
       })
     })
     .catch(error => {
@@ -948,10 +938,6 @@ const updateBaseParameter = (param: keyof BaseParameterSetting, value: any) => {
           baseParams.value = { ...baseParams.value, [param]: prev as BaseParameterSetting[typeof param] }
         },
       )
-    })
-    .finally(() => {
-      if (generation !== imageRequestGeneration.value) return
-      inFlightBaseWrites.value = Math.max(0, inFlightBaseWrites.value - 1)
     })
 }
 
@@ -977,7 +963,6 @@ const getBaseParameters = () => {
       }
       baseParams.value = pendingBase.mergeRemote(
         data as BaseParameterSetting,
-        baseParams.value,
       )
       console.log(data)
     })
@@ -1027,7 +1012,6 @@ const doRestoreBase = async () => {
   const cameraUuid = props.selectedCameraUuid
   const generation = imageRequestGeneration.value
   pendingBase.beginRestore()
-  inFlightBaseWrites.value++
   const payload: CameraControl = {
     camera_uuid: cameraUuid,
     action: "setImageAdjustment",
@@ -1045,14 +1029,13 @@ const doRestoreBase = async () => {
       ) {
         return
       }
-      baseParams.value = data as BaseParameterSetting
+      baseParams.value = pendingBase.mergeRemote(data as BaseParameterSetting)
     })
     .catch(error => {
       console.error("Error sending base image restore control:", error.message)
     })
     .finally(() => {
       if (generation !== imageRequestGeneration.value) return
-      inFlightBaseWrites.value = Math.max(0, inFlightBaseWrites.value - 1)
       processingBaseRestore.value = false
     })
 }
@@ -1066,7 +1049,6 @@ const updateAdvancedParam = (param: keyof AdvancedParameterSetting, value: any) 
   const previous = advancedParams.value[param]
   const { token, epoch } = pendingAdvanced.begin(param, previous, value)
   advancedParams.value = { ...advancedParams.value, [param]: value }
-  inFlightAdvancedWrites.value++
 
   const payload: CameraControl = {
     camera_uuid: cameraUuid,
@@ -1084,10 +1066,7 @@ const updateAdvancedParam = (param: keyof AdvancedParameterSetting, value: any) 
       }
       const incoming = data as AdvancedParameterSetting
       pendingAdvanced.settleSuccess(param, token, epoch, () => {
-        advancedParams.value = pendingAdvanced.mergeRemote(incoming, {
-          ...incoming,
-          [param]: value,
-        } as AdvancedParameterSetting)
+        advancedParams.value = pendingAdvanced.mergeRemote(incoming)
       })
     })
     .catch(error => {
@@ -1111,10 +1090,6 @@ const updateAdvancedParam = (param: keyof AdvancedParameterSetting, value: any) 
         },
       )
     })
-    .finally(() => {
-      if (generation !== imageRequestGeneration.value) return
-      inFlightAdvancedWrites.value = Math.max(0, inFlightAdvancedWrites.value - 1)
-    })
 }
 
 const doRestoreAdvanced = async () => {
@@ -1125,7 +1100,6 @@ const doRestoreAdvanced = async () => {
   const cameraUuid = props.selectedCameraUuid
   const generation = imageRequestGeneration.value
   pendingAdvanced.beginRestore()
-  inFlightAdvancedWrites.value++
   const payload: CameraControl = {
     camera_uuid: cameraUuid,
     action: "setImageAdjustmentEx",
@@ -1140,14 +1114,13 @@ const doRestoreAdvanced = async () => {
       ) {
         return
       }
-      advancedParams.value = data as AdvancedParameterSetting
+      advancedParams.value = pendingAdvanced.mergeRemote(data as AdvancedParameterSetting)
     })
     .catch(error => {
       console.error("Error restoring advanced parameters:", error.message)
     })
     .finally(() => {
       if (generation !== imageRequestGeneration.value) return
-      inFlightAdvancedWrites.value = Math.max(0, inFlightAdvancedWrites.value - 1)
       processingAdvancedRestore.value = false
     })
 }

--- a/frontend/src/components/StreamsTab.vue
+++ b/frontend/src/components/StreamsTab.vue
@@ -242,7 +242,8 @@ watch(
 watch(
   [selectedVideoParameters, selectedVideoResolution],
   () => {
-    if (!suppressUserEditFlag && !awaitingHydrate) {
+    // Allow dirty during hydrate so a successful fetch cannot clobber in-progress edits.
+    if (!suppressUserEditFlag) {
       hasUserEditedVideo.value = true
     }
   },
@@ -260,7 +261,7 @@ const applyCameraStateEvent = (body: unknown) => {
   if (awaitingRestartHydrate) {
     const settings = data.video_parameters as VideoParameterSettings
     const currentChannel = selectedVideoParameters.value.channel ?? VideoChannelValue.MainStream
-    if (settings.channel != null && settings.channel !== currentChannel) return
+    if (settings.channel !== currentChannel) return
     // First matching post-restart video snapshot — accept and clear the latch.
     update_video_parameter_values(settings)
     clearRestartHydrateLatch()
@@ -269,7 +270,7 @@ const applyCameraStateEvent = (body: unknown) => {
 
   const settings = data.video_parameters as VideoParameterSettings
   const currentChannel = selectedVideoParameters.value.channel ?? VideoChannelValue.MainStream
-  if (settings.channel != null && settings.channel !== currentChannel) return
+  if (settings.channel !== currentChannel) return
 
   update_video_parameter_values(settings)
 }
@@ -425,9 +426,16 @@ const getVideoParameters = (update: boolean) => {
         data as VideoParameterSettings
 
       if (update) {
-        update_video_parameter_values(settings)
-        if (awaitingRestartHydrate) {
+        if (!hasUserEditedVideo.value) {
+          update_video_parameter_values(settings)
+        }
+        if (awaitingRestartHydrate && !hasUserEditedVideo.value) {
           clearRestartHydrateLatch()
+        }
+        // End initial hydrate window even when dirty skipped the overwrite.
+        if (awaitingHydrate) {
+          awaitingHydrate = false
+          suppressUserEditFlag = false
         }
       }
     })

--- a/frontend/src/utils/actuatorFlight.selfcheck.ts
+++ b/frontend/src/utils/actuatorFlight.selfcheck.ts
@@ -28,21 +28,21 @@ export function runActuatorFlightSelfCheck(): void {
     !shouldRollbackActuatorUi({
       ownsFlight: true,
       queued: null,
-      desired: null,
+      desiredBeforeClear: 80,
       ui: 80,
       attempted: 80,
       rollback: 50,
       valuesMatch: match,
     })
   ) {
-    throw new Error('actuatorFlight: expected rollback when attempt still on UI')
+    throw new Error('actuatorFlight: expected rollback when attempt still desired')
   }
 
   if (
     shouldRollbackActuatorUi({
       ownsFlight: false,
       queued: null,
-      desired: null,
+      desiredBeforeClear: 80,
       ui: 80,
       attempted: 80,
       rollback: 50,
@@ -56,7 +56,7 @@ export function runActuatorFlightSelfCheck(): void {
     shouldRollbackActuatorUi({
       ownsFlight: true,
       queued: 90,
-      desired: null,
+      desiredBeforeClear: 80,
       ui: 80,
       attempted: 80,
       rollback: 50,
@@ -70,7 +70,7 @@ export function runActuatorFlightSelfCheck(): void {
     shouldRollbackActuatorUi({
       ownsFlight: true,
       queued: null,
-      desired: 90,
+      desiredBeforeClear: 90,
       ui: 90,
       attempted: 80,
       rollback: 50,
@@ -78,6 +78,20 @@ export function runActuatorFlightSelfCheck(): void {
     })
   ) {
     throw new Error('actuatorFlight: newer desired must block rollback')
+  }
+
+  if (
+    shouldRollbackActuatorUi({
+      ownsFlight: true,
+      queued: null,
+      desiredBeforeClear: null,
+      ui: 80,
+      attempted: 80,
+      rollback: 50,
+      valuesMatch: match,
+    })
+  ) {
+    throw new Error('actuatorFlight: SERVO-matched (desired null) must not rollback')
   }
 
   console.log('actuatorFlight self-check ok')

--- a/frontend/src/utils/actuatorFlight.ts
+++ b/frontend/src/utils/actuatorFlight.ts
@@ -28,13 +28,16 @@ export function ownsActuatorFlight(
 
 /**
  * Whether a failed POST should restore the pre-gesture UI value.
- * Caller should clear the desired latch for `attempted` before calling when
- * that latch still targets this attempt.
+ *
+ * Pass `desired` as it was *before* clearing the latch for this attempt.
+ * If SERVO already matched `attempted` (desired already cleared by state),
+ * skip rollback — hardware already reflects the command.
  */
 export function shouldRollbackActuatorUi(args: {
   ownsFlight: boolean
   queued: number | null
-  desired: number | null
+  /** Desired latch before any fail-path clear for this attempt. */
+  desiredBeforeClear: number | null
   ui: number | null
   attempted: number
   rollback: number | null
@@ -42,7 +45,17 @@ export function shouldRollbackActuatorUi(args: {
 }): boolean {
   if (!args.ownsFlight) return false
   if (args.queued !== null) return false
-  if (args.desired !== null) return false
+  // Newer desire still pending — leave optimistic UI alone.
+  if (
+    args.desiredBeforeClear !== null &&
+    !args.valuesMatch(args.desiredBeforeClear, args.attempted)
+  ) {
+    return false
+  }
+  // Desired already cleared because SERVO matched — do not snap back.
+  if (args.desiredBeforeClear === null) {
+    return false
+  }
   if (args.rollback === null || args.ui === null) return false
   return args.valuesMatch(args.ui, args.attempted)
 }

--- a/frontend/src/utils/backendClient.ts
+++ b/frontend/src/utils/backendClient.ts
@@ -467,6 +467,8 @@ class BackendClient {
       const previous = this.subscribedCameraUuid
       // Single active wire UUID: drop previous counts and unsubscribe once.
       this.cameraSubscribeCounts.delete(previous)
+      // Null before unsubscribe so the deferred/open guard does not drop the frame.
+      this.subscribedCameraUuid = null
       this.sendCameraSubscription('unsubscribe', previous)
     }
 

--- a/frontend/src/utils/pendingFields.selfcheck.ts
+++ b/frontend/src/utils/pendingFields.selfcheck.ts
@@ -26,12 +26,35 @@ export function runPendingFieldsSelfCheck(): void {
     throw new Error('pendingFields: success of B cleared A')
   }
 
-  const merged = pending.mergeRemote({ a: 99, b: 99 }, { a: 2, b: 11 })
+  // Pending A keeps entry.value (2), not a poisoned local or server 99.
+  const merged = pending.mergeRemote({ a: 99, b: 99 })
   if (merged.a !== 2) {
-    throw new Error('pendingFields: mergeRemote overwrote pending A')
+    throw new Error('pendingFields: mergeRemote did not keep entry.value for A')
   }
   if (merged.b !== 99) {
-    throw new Error('pendingFields: mergeRemote kept settled B local')
+    throw new Error('pendingFields: mergeRemote should take server B after settle')
+  }
+
+  // Settle A then merge: only remaining pending keys are protected.
+  const pending2 = createPendingFields<'a' | 'b', number>()
+  const pa = pending2.begin('a', 0, 1)
+  pending2.begin('b', 10, 11)
+  pending2.settleSuccess('a', pa.token, pa.epoch, () => {})
+  const afterSettle = pending2.mergeRemote({ a: 50, b: 50 })
+  if (afterSettle.a !== 50) {
+    throw new Error('pendingFields: settled A should take server value')
+  }
+  if (afterSettle.b !== 11) {
+    throw new Error('pendingFields: pending B must keep entry.value after sibling settle')
+  }
+
+  // Restore then edit then late restore response must not wipe the new pending.
+  const pending3 = createPendingFields<'a', number>()
+  pending3.beginRestore()
+  pending3.begin('a', 0, 7)
+  const late = pending3.mergeRemote({ a: 1 })
+  if (late.a !== 7) {
+    throw new Error('pendingFields: late restore merge overwrote post-restore edit')
   }
 
   pending.beginRestore()

--- a/frontend/src/utils/pendingFields.ts
+++ b/frontend/src/utils/pendingFields.ts
@@ -2,8 +2,8 @@
  * Per-field optimistic write ownership.
  *
  * Each in-flight field write gets a token. Success/fail only settles that token.
- * Remote merges never overwrite pending keys. Restore bumps epoch so late
- * per-field settles are ignored.
+ * Remote merges always keep `entry.value` for pending keys (never trust a caller
+ * local). Restore bumps epoch so late per-field settles are ignored.
  */
 export type PendingEntry<V> = {
   token: number
@@ -26,7 +26,7 @@ export function createPendingFields<K extends string, V>() {
     key: K,
     token: number,
     settleEpoch: number,
-    applySettled: (previousLocal: V) => void,
+    applySettled: (attempted: V) => void,
   ): boolean => {
     if (settleEpoch !== epoch) return false
     const entry = pending.get(key)
@@ -53,16 +53,12 @@ export function createPendingFields<K extends string, V>() {
     return true
   }
 
-  const mergeRemote = <T extends Record<string, unknown>>(
-    incoming: T,
-    local: T,
-  ): T => {
+  /** Merge remote snapshot; pending keys always win via `entry.value`. */
+  const mergeRemote = <T extends Record<string, unknown>>(incoming: T): T => {
     if (pending.size === 0) return incoming
     const merged = { ...incoming }
-    for (const key of pending.keys()) {
-      if (key in local) {
-        ;(merged as Record<string, unknown>)[key] = local[key as keyof T]
-      }
+    for (const [key, entry] of pending) {
+      ;(merged as Record<string, unknown>)[key] = entry.value
     }
     return merged
   }

--- a/frontend/src/utils/runSelfChecks.ts
+++ b/frontend/src/utils/runSelfChecks.ts
@@ -1,0 +1,5 @@
+import { runActuatorFlightSelfCheck } from './actuatorFlight.selfcheck'
+import { runPendingFieldsSelfCheck } from './pendingFields.selfcheck'
+
+runPendingFieldsSelfCheck()
+runActuatorFlightSelfCheck()


### PR DESCRIPTION
## Summary
Split from the websockets work: **pendingFields settle, Streams hydrate, actuator rollback**.

Commits in this slice:
- `frontend: pendingFields merge from entry.value; fix settle/restore`
- `frontend: Fix subscribe session and Streams hydrate dirty`
- `frontend: Actuator rollback desired semantics and selfcheck script`

## Stack
- Part **20/24** of the websockets split (all PRs target `master`)
- Depends on https://github.com/bluerobotics/radcam-manager/pull/220 merging first.
- After the previous stack PR merges: rebase this branch onto `master` and `git push --force-with-lease`
- Intermediate slices may show **red CI** (incomplete stack / missing later fixes). That is expected.
- The batch is only done when tip **[#225](https://github.com/bluerobotics/radcam-manager/pull/225)** (`24/24`) is green after the full merge-rebase dance.

## Test plan
- [ ] Failed actuator writes roll back to the last desired/confirmed value for that token only
- [ ] StreamsTab hydrate after restart does not flash stale dirty channel state
- [ ] `pendingFields` merge uses `entry.value` correctly on success/fail settle
