### PR TITLE
websockets 21/24: Fix ArduPilot param encode and MANAGER registration order

### DIFF
--- a/backend/libs/autopilot/src/manager/mod.rs
+++ b/backend/libs/autopilot/src/manager/mod.rs
@@ -327,27 +327,30 @@ pub async fn init(
 ) -> Result<()> {
     let settings = State::from_settings().await?;
 
+    // Publish settings before MAVLink param sync so GetActuatorsConfig works while
+    // try_new is still downloading parameters (can take tens of seconds).
     if let Some(manager) = MANAGER.get() {
         let _apply = CONFIG_APPLY.lock().await;
         let mut guard = manager.write().await;
-        guard.autopilot_scripts_file = autopilot_scripts_file;
+        guard.autopilot_scripts_file = autopilot_scripts_file.clone();
         guard.settings = settings;
+    } else {
+        MANAGER.get_or_init(|| {
+            RwLock::new(Manager {
+                autopilot_scripts_file: autopilot_scripts_file.clone(),
+                settings,
+                script_health: ScriptHealthTracker::default(),
+            })
+        });
+    }
+
+    if mavlink::component().is_ok() {
         return Ok(());
     }
 
     let mavlink =
         MavlinkComponent::try_new(mavlink_address, mavlink_system_id, mavlink_component_id).await?;
     mavlink::init_component(mavlink)?;
-
-    let script_health = ScriptHealthTracker::default();
-
-    MANAGER.get_or_init(|| {
-        RwLock::new(Manager {
-            autopilot_scripts_file,
-            settings,
-            script_health,
-        })
-    });
 
     crate::actuators_watch::start();
 

--- a/backend/libs/autopilot/src/mavlink/parameters.rs
+++ b/backend/libs/autopilot/src/mavlink/parameters.rs
@@ -92,7 +92,15 @@ impl MavlinkComponent {
 
             let encoding_c_cast = data
                 .capabilities
-                .contains(MavProtocolCapability::MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_C_CAST);
+                .contains(MavProtocolCapability::MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_C_CAST)
+                || {
+                    // Deprecated alias of C_CAST (renamed 2022-03); still set by some stacks.
+                    #[allow(deprecated)]
+                    {
+                        data.capabilities
+                            .contains(MavProtocolCapability::MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT)
+                    }
+                };
             let encoding_bytewise = data
                 .capabilities
                 .contains(MavProtocolCapability::MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_BYTEWISE);
@@ -111,10 +119,19 @@ impl MavlinkComponent {
                     break ParamEncodingType::ByteWise;
                 }
                 (false, false) => {
+                    // Spec: either bit *should* be set if params are supported, but the
+                    // protocol may still be used with prior knowledge of the component
+                    // (https://mavlink.io/en/services/parameter.html#protocol-discovery).
+                    // ArduPilot uses C-cast encoding and does *not* set
+                    // MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_C_CAST
+                    // (https://mavlink.io/en/services/parameter.html#ardupilot).
+                    // Storing Unsupported here made Parameter::try_new fail for every
+                    // PARAM_VALUE, so update_all_params never finished and MANAGER
+                    // never registered — settings.json stayed out of sync with runtime.
                     error!(
-                        "Unexpected value: None of the C_CAST and BYTEWISE encodings are set by the Autopilot. Assuming C_CAST, then."
+                        "Neither PARAM_ENCODE_C_CAST nor PARAM_ENCODE_BYTEWISE set; assuming C_CAST (ArduPilot)"
                     );
-                    break ParamEncodingType::Unsupported;
+                    break ParamEncodingType::CCast;
                 }
             }
         };


### PR DESCRIPTION
## Summary
Split from the websockets work: **Fix ArduPilot param encode and MANAGER registration order**.

Commits in this slice:
- `backend: libs: autopilot: Assume CCast when ArduPilot omits param encode bits`
- `backend: libs: autopilot: Register MANAGER before MAVLink param sync`

## Stack
- Part **21/24** of the websockets split (all PRs target `master`)
- Depends on https://github.com/bluerobotics/radcam-manager/pull/221 merging first.
- After the previous stack PR merges: rebase this branch onto `master` and `git push --force-with-lease`
- Intermediate slices may show **red CI** (incomplete stack / missing later fixes). That is expected.
- The batch is only done when tip **[#225](https://github.com/bluerobotics/radcam-manager/pull/225)** (`24/24`) is green after the full merge-rebase dance.

## Test plan
- [ ] ArduPilot vehicles that omit param-encode bits still sync parameters (C-cast assumption)
- [ ] `MANAGER` is registered before MAVLink param sync so MANAGER-backed features are available after boot
- [ ] Cold start on vehicle: no permanent “Hardware Setup Required” / param hang from encode mismatch
