### PR TITLE
websockets 22/24: Add one_push_awb API, bindings, and sceneMode Off

### DIFF
--- a/backend/bindings_generator/src/main.rs
+++ b/backend/bindings_generator/src/main.rs
@@ -167,6 +167,8 @@ fn generate_typescript_bindings_for_radcam_api() -> Result<()> {
     let ts_rs_bindings = [
         radcam_api::CameraStateEvent::export_to_string()?,
         radcam_api::CameraUiState::export_to_string()?,
+        radcam_api::OnePushAwbStatus::export_to_string()?,
+        radcam_api::OnePushAwbPhase::export_to_string()?,
         radcam_api::ConnectionStats::export_to_string()?,
         radcam_api::WsRequest::export_to_string()?,
         radcam_api::WsClientMessage::export_to_string()?,

--- a/backend/libs/radcam_api/src/lib.rs
+++ b/backend/libs/radcam_api/src/lib.rs
@@ -37,6 +37,27 @@ pub struct CameraUiState {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub warning_toast: Option<String>,
+    /// One-push white balance lifecycle shared across clients. Absent = idle.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub one_push_awb: Option<OnePushAwbStatus>,
+}
+
+/// Phase of a backend-owned one-push white balance run.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum OnePushAwbPhase {
+    /// Camera is adjusting gains after `onceAWB`.
+    Running,
+    /// Settled; clients must keep WB controls disabled briefly.
+    Cooldown,
+}
+
+/// Shared one-push white balance status broadcast on [`CameraUiState`].
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, TS)]
+pub struct OnePushAwbStatus {
+    /// Current phase of the run.
+    pub phase: OnePushAwbPhase,
 }
 
 /// Partial camera state pushed to subscribed WebSocket clients.

--- a/backend/libs/radcam_commands/src/protocol/display/base_display.rs
+++ b/backend/libs/radcam_commands/src/protocol/display/base_display.rs
@@ -139,7 +139,9 @@ pub enum BaseFrameTurboValue {
 #[tsync]
 #[repr(u8)]
 pub enum BaseSceneModeValue {
+    /// Camera firmware reports 0 when no capture scene is selected.
     #[default]
+    Off = 0,
     FaceCapture = 1,
     LicensePlateCapture = 2,
 }


### PR DESCRIPTION
## Summary
Split from the websockets work: **Add one_push_awb API, bindings, and sceneMode Off**.

Commits in this slice:
- `backend: libs: radcam_api: Add one_push_awb to CameraUiState`
- `backend: bindings_generator: Export OnePushAwb TS bindings`
- `backend: libs: radcam_commands: Add BaseSceneModeValue::Off for sceneMode 0`

## Stack
- Part **22/24** of the websockets split (all PRs target `master`)
- Depends on https://github.com/bluerobotics/radcam-manager/pull/222 merging first.
- After the previous stack PR merges: rebase this branch onto `master` and `git push --force-with-lease`
- Intermediate slices may show **red CI** (incomplete stack / missing later fixes). That is expected.
- The batch is only done when tip **[#225](https://github.com/bluerobotics/radcam-manager/pull/225)** (`24/24`) is green after the full merge-rebase dance.

## Test plan
- [ ] `CameraUiState.one_push_awb` appears in API + generated TS bindings
- [ ] `BaseSceneModeValue::Off` (0) deserializes from camera `sceneMode: 0`
- [ ] Idle cameras omit `one_push_awb` on the wire (`skip_serializing_if`)
