### PR TITLE
websockets 23/24: Backend-owned one-push AWB lifecycle and settle

### DIFF
--- a/backend/libs/radcam_manager/src/web/camera_state.rs
+++ b/backend/libs/radcam_manager/src/web/camera_state.rs
@@ -493,7 +493,7 @@ fn state_sender() -> &'static broadcast::Sender<CameraStateEvent> {
 }
 
 #[instrument(level = "debug", skip_all, fields(%event.camera_uuid))]
-fn emit(mut event: CameraStateEvent) {
+pub(crate) fn emit(mut event: CameraStateEvent) {
     record_partial(&mut event);
     // record_partial is a no-op without interest; skip waking every WS filter.
     if !has_interest(event.camera_uuid) {
@@ -693,6 +693,7 @@ fn ensure_camera_list_watcher() {
                 Ok(()) | Err(broadcast::error::RecvError::Lagged(_)) => {
                     let known: HashSet<Uuid> =
                         mcm_client::cameras().await.keys().copied().collect();
+                    crate::web::one_push_awb::retain_known_cameras(&known);
                     retain_known_cameras(&known);
                     camera_ui::retain_known_cameras(&known);
                 }

--- a/backend/libs/radcam_manager/src/web/camera_ui.rs
+++ b/backend/libs/radcam_manager/src/web/camera_ui.rs
@@ -9,7 +9,7 @@ use std::{
 
 use autopilot::api::{Action as AutopilotAction, ActuatorsConfig};
 use once_cell::sync::OnceCell;
-use radcam_api::{CameraUiState, UiDismissField};
+use radcam_api::{CameraUiState, OnePushAwbStatus, UiDismissField};
 use radcam_commands::Action as CameraAction;
 use tokio::task::JoinHandle;
 use tracing::*;
@@ -57,6 +57,18 @@ pub(crate) fn retain_known_cameras(known: &HashSet<Uuid>) {
         clear_min_loading_timeout(entry);
         false
     });
+}
+
+/// Set or clear the shared one-push AWB phase for all clients.
+#[instrument(level = "debug")]
+pub(crate) fn set_one_push_awb(camera_uuid: Uuid, status: Option<OnePushAwbStatus>) {
+    let state = {
+        let mut lock = ui().lock().unwrap();
+        let entry = lock.entry(camera_uuid).or_insert_with(new_entry);
+        entry.state.one_push_awb = status;
+        entry.state.clone()
+    };
+    camera_state::emit_ui(camera_uuid, state);
 }
 
 /// Dismiss a UI overlay field for all clients.
@@ -339,7 +351,7 @@ fn set_error(camera_uuid: Uuid, message: String) {
 
 /// Show a transient warning toast; suppressed while rebooting.
 #[instrument(level = "debug")]
-fn set_warning(camera_uuid: Uuid, message: String) {
+pub(crate) fn set_warning(camera_uuid: Uuid, message: String) {
     if autopilot::error_indicates_actuators_not_configured(&message) {
         return;
     }

--- a/backend/libs/radcam_manager/src/web/control_bridge.rs
+++ b/backend/libs/radcam_manager/src/web/control_bridge.rs
@@ -2,10 +2,10 @@
 //! (REST and WebSocket alike) produces the same UI overlay and state updates.
 
 use autopilot::api::ActuatorsControl;
-use radcam_commands::CameraControl;
+use radcam_commands::{Action as CameraAction, CameraControl};
 use serde_json::Value;
 
-use crate::web::{camera_state, camera_ui};
+use crate::web::{camera_state, camera_ui, one_push_awb};
 
 /// Wire / HTTP body when the requested camera UUID is not in the MCM list.
 pub(crate) const UNKNOWN_CAMERA: &str = "unknown camera";
@@ -41,12 +41,23 @@ pub(crate) async fn camera_control(camera_control: CameraControl) -> Result<Valu
         return Err(ControlError::unknown_camera());
     }
     let action = camera_control.action.clone();
+
+    // Concurrent onceAWB while Running/Cooldown is a no-op success (do not restart).
+    if matches!(
+        &action,
+        CameraAction::SetImageAdjustmentEx(params) if params.once_awb == Some(1)
+    ) && one_push_awb::is_busy(camera_uuid)
+    {
+        return Ok(Value::Null);
+    }
+
     camera_ui::start_camera_action(camera_uuid, &action);
 
     match radcam_commands::handle_control(camera_control).await {
         Ok(value) => {
             camera_ui::finish_camera_action(camera_uuid, &action);
             camera_state::emit_camera_control_update(camera_uuid, &action, &value);
+            one_push_awb::on_control_success(camera_uuid, &action);
             Ok(value)
         }
         Err(error) => {

--- a/backend/libs/radcam_manager/src/web/mod.rs
+++ b/backend/libs/radcam_manager/src/web/mod.rs
@@ -12,6 +12,7 @@ use tracing::*;
 pub(crate) mod camera_state;
 pub(crate) mod camera_ui;
 pub(crate) mod control_bridge;
+pub(crate) mod one_push_awb;
 pub mod routes;
 pub(crate) mod ws_connections;
 

--- a/backend/libs/radcam_manager/src/web/one_push_awb.rs
+++ b/backend/libs/radcam_manager/src/web/one_push_awb.rs
@@ -3,34 +3,48 @@
 //! Pure settle logic is unit-tested; the tracker polls base parameters and drives
 //! [`camera_ui`] / [`camera_state`] so every client stays in sync.
 
-use std::{collections::HashMap, sync::Mutex, time::Instant};
+use std::{
+    collections::HashMap,
+    sync::{
+        Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Instant,
+};
 
 use once_cell::sync::OnceCell;
 use radcam_api::{CameraStateEvent, OnePushAwbPhase, OnePushAwbStatus};
-use radcam_commands::{
-    Action as CameraAction, CameraControl,
-    protocol::display::base_display::{BaseAutoWhiteBalanceModeValue, BaseParameterSetting},
-};
+use radcam_commands::{Action as CameraAction, CameraControl};
 use tokio::task::JoinHandle;
 use tracing::*;
 use uuid::Uuid;
 
 use crate::web::{camera_state, camera_ui};
 
-/// Consecutive identical RGB samples required after movement before settle (Auto path).
+/// Consecutive identical Manual RGB samples required after movement before settle.
 pub const STABLE_SAMPLES: u8 = 2;
-/// Wall-clock ceiling for a Running phase.
+/// Wall-clock ceiling while waiting for Manual RGB to move and hold steady.
 pub const RUN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
-/// How long clients keep WB controls disabled after settle.
-pub const COOLDOWN: std::time::Duration = std::time::Duration::from_secs(3);
+/// Minimum time WB controls stay busy from trigger (Cooldown fills any shortfall).
+pub const MIN_BUSY: std::time::Duration = std::time::Duration::from_secs(1);
 /// Poll interval while Running.
 pub const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// `auto_awb` value for Manual in the camera protocol (`BaseAutoWhiteBalanceModeValue::Manual`).
+const AUTO_AWB_MANUAL: u8 = 1;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RgbSample {
     pub red: u8,
     pub green: u8,
     pub blue: u8,
+}
+
+/// WB fields pulled from a getImageAdjustment JSON body (ignores unrelated enums).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AwbSample {
+    pub rgb: Option<RgbSample>,
+    pub auto_awb: Option<u8>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -49,40 +63,57 @@ pub enum ObserveResult {
 
 struct TrackerEntry {
     handle: JoinHandle<()>,
+    generation: u64,
 }
 
 static TRACKERS: OnceCell<Mutex<HashMap<Uuid, TrackerEntry>>> = OnceCell::new();
+static NEXT_GENERATION: AtomicU64 = AtomicU64::new(1);
 
-impl RgbSample {
-    pub fn from_base(base: &BaseParameterSetting) -> Option<Self> {
-        Some(Self {
-            red: base.awb_red?,
-            green: base.awb_green?,
-            blue: base.awb_blue?,
-        })
+impl AwbSample {
+    /// Read only AWB fields so unknown/extra camera enums cannot abort the tracker.
+    pub fn from_json(value: &serde_json::Value) -> Self {
+        let u8_field = |name: &str| value.get(name).and_then(|v| v.as_u64()).map(|v| v as u8);
+        let red = u8_field("awb_red");
+        let green = u8_field("awb_green");
+        let blue = u8_field("awb_blue");
+        let rgb = match (red, green, blue) {
+            (Some(red), Some(green), Some(blue)) => Some(RgbSample { red, green, blue }),
+            _ => None,
+        };
+        Self {
+            rgb,
+            auto_awb: u8_field("auto_awb"),
+        }
     }
 }
 
 impl SettleMachine {
-    pub fn begin(start: &BaseParameterSetting) -> Self {
-        let rgb = RgbSample::from_base(start);
+    pub fn begin(start: &AwbSample) -> Self {
         Self {
-            start_rgb: rgb,
-            last_rgb: rgb,
+            start_rgb: start.rgb,
+            last_rgb: start.rgb,
             saw_change: false,
             stable_count: 0,
         }
     }
 
-    /// Feed a base-parameter sample. Settles on Manual-after-change or RGB stability.
-    pub fn observe(&mut self, sample: &BaseParameterSetting) -> ObserveResult {
-        let rgb = RgbSample::from_base(sample);
-        if let Some(current) = rgb {
+    pub fn saw_change(&self) -> bool {
+        self.saw_change
+    }
+
+    /// Feed a base-parameter sample.
+    ///
+    /// Settles only after RGB has moved and then held steady while Manual — never on
+    /// Manual alone or an unchanged Manual snapshot (onceAWB often lags before gains move).
+    pub fn observe(&mut self, sample: &AwbSample) -> ObserveResult {
+        let manual = sample.auto_awb == Some(AUTO_AWB_MANUAL);
+
+        if let Some(current) = sample.rgb {
             if let Some(last) = self.last_rgb {
                 if current != last {
                     self.saw_change = true;
                     self.stable_count = 0;
-                } else if self.saw_change {
+                } else if self.saw_change && manual {
                     self.stable_count = self.stable_count.saturating_add(1);
                 }
             }
@@ -94,12 +125,7 @@ impl SettleMachine {
             self.last_rgb = Some(current);
         }
 
-        let manual = matches!(sample.auto_awb, Some(BaseAutoWhiteBalanceModeValue::Manual));
-
-        if self.saw_change && manual {
-            return ObserveResult::Settled;
-        }
-        if self.saw_change && self.stable_count >= STABLE_SAMPLES {
+        if self.saw_change && manual && self.stable_count >= STABLE_SAMPLES {
             return ObserveResult::Settled;
         }
         ObserveResult::Continue
@@ -151,6 +177,8 @@ pub(crate) fn begin_after_trigger(camera_uuid: Uuid) {
         return;
     }
 
+    let generation = NEXT_GENERATION.fetch_add(1, Ordering::Relaxed);
+
     {
         let mut lock = trackers().lock().unwrap();
         if let Some(entry) = lock.remove(&camera_uuid) {
@@ -165,11 +193,11 @@ pub(crate) fn begin_after_trigger(camera_uuid: Uuid) {
         }),
     );
 
-    let handle = tokio::spawn(run_tracker(camera_uuid).instrument(Span::current()));
+    let handle = tokio::spawn(run_tracker(camera_uuid, generation).instrument(Span::current()));
     trackers()
         .lock()
         .unwrap()
-        .insert(camera_uuid, TrackerEntry { handle });
+        .insert(camera_uuid, TrackerEntry { handle, generation });
 }
 
 /// After a successful control that included onceAWB, start trackers.
@@ -203,170 +231,291 @@ fn trackers() -> &'static Mutex<HashMap<Uuid, TrackerEntry>> {
     TRACKERS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-#[instrument(level = "debug", skip_all, fields(%camera_uuid))]
-async fn run_tracker(camera_uuid: Uuid) {
+fn is_current_generation(camera_uuid: Uuid, generation: u64) -> bool {
+    trackers()
+        .lock()
+        .unwrap()
+        .get(&camera_uuid)
+        .is_some_and(|entry| entry.generation == generation)
+}
+
+#[instrument(level = "debug", skip_all, fields(%camera_uuid, generation))]
+async fn run_tracker(camera_uuid: Uuid, generation: u64) {
     let start = Instant::now();
-    let initial = match fetch_base_setting(camera_uuid).await {
-        Ok(base) => base,
-        Err(error) => {
-            warn!("one-push AWB start snapshot failed: {error}");
-            finish_timeout(camera_uuid);
-            return;
+
+    // Retry the opening snapshot — a single failed GET right after onceAWB used to
+    // finish_timeout immediately and clear the button in well under a second.
+    let (initial_json, initial) = loop {
+        match fetch_base_json(camera_uuid).await {
+            Ok(value) => {
+                let sample = AwbSample::from_json(&value);
+                break (value, sample);
+            }
+            Err(error) => {
+                warn!("one-push AWB start snapshot failed: {error}");
+                if !is_current_generation(camera_uuid, generation) {
+                    return;
+                }
+                if start.elapsed() >= RUN_TIMEOUT {
+                    finish_timeout(camera_uuid, generation);
+                    return;
+                }
+                tokio::time::sleep(POLL_INTERVAL).await;
+            }
         }
     };
 
-    // Push the start snapshot so clients see gains as soon as the run begins.
-    if let Ok(value) = serde_json::to_value(&initial) {
-        camera_state::emit(CameraStateEvent {
-            camera_uuid,
-            base_parameters: Some(value),
-            ..Default::default()
-        });
+    if !is_current_generation(camera_uuid, generation) {
+        return;
     }
+
+    camera_state::emit(CameraStateEvent {
+        camera_uuid,
+        base_parameters: Some(initial_json),
+        ..Default::default()
+    });
 
     let mut machine = SettleMachine::begin(&initial);
     let mut last_emitted = initial.clone();
 
     loop {
         tokio::time::sleep(POLL_INTERVAL).await;
-
-        if start.elapsed() >= RUN_TIMEOUT {
-            finish_timeout(camera_uuid);
+        if !is_current_generation(camera_uuid, generation) {
             return;
         }
 
-        let sample = match fetch_base_setting(camera_uuid).await {
-            Ok(base) => base,
+        let sample_json = match fetch_base_json(camera_uuid).await {
+            Ok(value) => value,
             Err(error) => {
                 warn!("one-push AWB poll failed: {error}");
+                if start.elapsed() >= RUN_TIMEOUT {
+                    if machine.saw_change() {
+                        finish_timeout(camera_uuid, generation);
+                    } else {
+                        finish_settled(camera_uuid, start, generation).await;
+                    }
+                    return;
+                }
                 continue;
             }
         };
+        let sample = AwbSample::from_json(&sample_json);
 
-        if sample != last_emitted
-            && let Ok(value) = serde_json::to_value(&sample)
-        {
+        if sample != last_emitted {
             camera_state::emit(CameraStateEvent {
                 camera_uuid,
-                base_parameters: Some(value),
+                base_parameters: Some(sample_json),
                 ..Default::default()
             });
             last_emitted = sample.clone();
         }
 
+        // Do not quiet-settle on unchanged Manual mid-run: onceAWB often leaves gains
+        // untouched for several seconds before they move.
         if machine.observe(&sample) == ObserveResult::Settled {
-            finish_settled(camera_uuid).await;
+            finish_settled(camera_uuid, start, generation).await;
+            return;
+        }
+
+        if start.elapsed() >= RUN_TIMEOUT {
+            if machine.saw_change() {
+                finish_timeout(camera_uuid, generation);
+            } else {
+                finish_settled(camera_uuid, start, generation).await;
+            }
             return;
         }
     }
 }
 
-async fn finish_settled(camera_uuid: Uuid) {
-    camera_ui::set_one_push_awb(
-        camera_uuid,
-        Some(OnePushAwbStatus {
-            phase: OnePushAwbPhase::Cooldown,
-        }),
-    );
-    tokio::time::sleep(COOLDOWN).await;
-    // Only clear if we are still the cooldown owner (no newer run).
-    if matches!(
-        camera_ui::get(camera_uuid)
-            .one_push_awb
-            .as_ref()
-            .map(|status| status.phase),
-        Some(OnePushAwbPhase::Cooldown)
-    ) {
-        camera_ui::set_one_push_awb(camera_uuid, None);
+/// Hold Cooldown only long enough to honour [`MIN_BUSY`] from `started_at`.
+async fn finish_settled(camera_uuid: Uuid, started_at: Instant, generation: u64) {
+    if !is_current_generation(camera_uuid, generation) {
+        return;
     }
-    trackers().lock().unwrap().remove(&camera_uuid);
+    let remaining = MIN_BUSY.saturating_sub(started_at.elapsed());
+    if !remaining.is_zero() {
+        camera_ui::set_one_push_awb(
+            camera_uuid,
+            Some(OnePushAwbStatus {
+                phase: OnePushAwbPhase::Cooldown,
+            }),
+        );
+        tokio::time::sleep(remaining).await;
+        if !is_current_generation(camera_uuid, generation) {
+            return;
+        }
+    }
+    camera_ui::set_one_push_awb(camera_uuid, None);
+    remove_tracker_if_current(camera_uuid, generation);
 }
 
-fn finish_timeout(camera_uuid: Uuid) {
+fn finish_timeout(camera_uuid: Uuid, generation: u64) {
+    if !is_current_generation(camera_uuid, generation) {
+        return;
+    }
     camera_ui::set_warning(camera_uuid, "One-push white balance timed out".to_string());
     camera_ui::set_one_push_awb(camera_uuid, None);
-    trackers().lock().unwrap().remove(&camera_uuid);
+    remove_tracker_if_current(camera_uuid, generation);
 }
 
-async fn fetch_base_setting(camera_uuid: Uuid) -> Result<BaseParameterSetting, String> {
-    let value = radcam_commands::handle_control(CameraControl {
+fn remove_tracker_if_current(camera_uuid: Uuid, generation: u64) {
+    let mut lock = trackers().lock().unwrap();
+    if lock
+        .get(&camera_uuid)
+        .is_some_and(|entry| entry.generation == generation)
+    {
+        lock.remove(&camera_uuid);
+    }
+}
+
+async fn fetch_base_json(camera_uuid: Uuid) -> Result<serde_json::Value, String> {
+    radcam_commands::handle_control(CameraControl {
         camera_uuid,
         action: CameraAction::GetImageAdjustment,
     })
     .await
-    .map_err(|error| format!("{error:?}"))?;
-    serde_json::from_value(value).map_err(|error| error.to_string())
+    .map_err(|error| format!("{error:?}"))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn base(r: u8, g: u8, b: u8, manual: bool) -> BaseParameterSetting {
-        BaseParameterSetting {
-            awb_red: Some(r),
-            awb_green: Some(g),
-            awb_blue: Some(b),
-            auto_awb: Some(if manual {
-                BaseAutoWhiteBalanceModeValue::Manual
-            } else {
-                BaseAutoWhiteBalanceModeValue::Auto
+    fn sample(r: u8, g: u8, b: u8, manual: bool) -> AwbSample {
+        AwbSample {
+            rgb: Some(RgbSample {
+                red: r,
+                green: g,
+                blue: b,
             }),
-            ..Default::default()
+            auto_awb: Some(if manual { AUTO_AWB_MANUAL } else { 0 }),
         }
     }
 
     #[test]
-    fn manual_after_rgb_change_settles() {
-        let start = base(10, 20, 30, false);
+    fn awb_sample_ignores_unrelated_fields() {
+        let value = serde_json::json!({
+            "sceneMode": 0,
+            "auto_awb": 1,
+            "awb_red": 10,
+            "awb_green": 20,
+            "awb_blue": 30,
+            "extra_future_field": true,
+        });
+        assert_eq!(AwbSample::from_json(&value), sample(10, 20, 30, true));
+    }
+
+    #[test]
+    fn manual_after_rgb_change_needs_stable_samples() {
+        let start = sample(10, 20, 30, false);
         let mut machine = SettleMachine::begin(&start);
         assert_eq!(
-            machine.observe(&base(11, 20, 30, false)),
+            machine.observe(&sample(11, 20, 30, false)),
             ObserveResult::Continue
         );
         assert_eq!(
-            machine.observe(&base(11, 20, 30, true)),
+            machine.observe(&sample(11, 20, 30, true)),
+            ObserveResult::Continue
+        );
+        assert_eq!(
+            machine.observe(&sample(11, 20, 30, true)),
             ObserveResult::Settled
         );
     }
 
     #[test]
-    fn already_manual_settles_on_first_rgb_change() {
-        let start = base(10, 20, 30, true);
+    fn already_manual_needs_stable_rgb_after_change() {
+        let start = sample(10, 20, 30, true);
         let mut machine = SettleMachine::begin(&start);
         assert_eq!(
-            machine.observe(&base(40, 20, 30, true)),
+            machine.observe(&sample(40, 20, 30, true)),
+            ObserveResult::Continue
+        );
+        assert_eq!(
+            machine.observe(&sample(40, 20, 30, true)),
+            ObserveResult::Continue
+        );
+        assert_eq!(
+            machine.observe(&sample(40, 20, 30, true)),
             ObserveResult::Settled
         );
     }
 
     #[test]
-    fn auto_settles_on_rgb_stability() {
-        let start = base(10, 20, 30, false);
-        let mut machine = SettleMachine::begin(&start);
-        assert_eq!(
-            machine.observe(&base(40, 20, 30, false)),
-            ObserveResult::Continue
-        );
-        assert_eq!(
-            machine.observe(&base(40, 20, 30, false)),
-            ObserveResult::Continue
-        );
-        assert_eq!(
-            machine.observe(&base(40, 20, 30, false)),
-            ObserveResult::Settled
-        );
-    }
-
-    #[test]
-    fn no_change_never_settles() {
-        let start = base(10, 20, 30, true);
+    fn unchanged_manual_does_not_settle_early() {
+        // Repro: Manual gains set, onceAWB triggered — camera lags before RGB moves.
+        let start = sample(41, 128, 81, true);
         let mut machine = SettleMachine::begin(&start);
         for _ in 0..5 {
             assert_eq!(
-                machine.observe(&base(10, 20, 30, true)),
+                machine.observe(&sample(41, 128, 81, true)),
                 ObserveResult::Continue
             );
         }
+        assert!(!machine.saw_change());
+    }
+
+    #[test]
+    fn auto_rgb_stability_waits_for_manual_then_hold() {
+        let start = sample(10, 20, 30, false);
+        let mut machine = SettleMachine::begin(&start);
+        assert_eq!(
+            machine.observe(&sample(40, 20, 30, false)),
+            ObserveResult::Continue
+        );
+        // Auto identical samples do not accumulate Manual stability.
+        assert_eq!(
+            machine.observe(&sample(40, 20, 30, false)),
+            ObserveResult::Continue
+        );
+        assert_eq!(
+            machine.observe(&sample(40, 20, 30, true)),
+            ObserveResult::Continue
+        );
+        assert_eq!(
+            machine.observe(&sample(40, 20, 30, true)),
+            ObserveResult::Settled
+        );
+    }
+
+    #[test]
+    fn mid_hunt_rgb_change_resets_stability() {
+        let start = sample(41, 128, 81, true);
+        let mut machine = SettleMachine::begin(&start);
+        assert_eq!(
+            machine.observe(&sample(50, 128, 90, true)),
+            ObserveResult::Continue
+        );
+        assert_eq!(
+            machine.observe(&sample(50, 128, 90, true)),
+            ObserveResult::Continue
+        );
+        // Still hunting — stability resets.
+        assert_eq!(
+            machine.observe(&sample(55, 128, 95, true)),
+            ObserveResult::Continue
+        );
+        assert_eq!(
+            machine.observe(&sample(55, 128, 95, true)),
+            ObserveResult::Continue
+        );
+        assert_eq!(
+            machine.observe(&sample(55, 128, 95, true)),
+            ObserveResult::Settled
+        );
+    }
+
+    #[test]
+    fn min_busy_remaining_is_zero_after_floor() {
+        assert_eq!(MIN_BUSY.saturating_sub(MIN_BUSY), std::time::Duration::ZERO);
+        assert_eq!(
+            MIN_BUSY.saturating_sub(MIN_BUSY + std::time::Duration::from_millis(1)),
+            std::time::Duration::ZERO
+        );
+        assert_eq!(
+            MIN_BUSY.saturating_sub(std::time::Duration::from_millis(250)),
+            std::time::Duration::from_millis(750)
+        );
     }
 }

--- a/backend/libs/radcam_manager/src/web/one_push_awb.rs
+++ b/backend/libs/radcam_manager/src/web/one_push_awb.rs
@@ -1,0 +1,372 @@
+//! Backend-owned one-push white balance lifecycle.
+//!
+//! Pure settle logic is unit-tested; the tracker polls base parameters and drives
+//! [`camera_ui`] / [`camera_state`] so every client stays in sync.
+
+use std::{collections::HashMap, sync::Mutex, time::Instant};
+
+use once_cell::sync::OnceCell;
+use radcam_api::{CameraStateEvent, OnePushAwbPhase, OnePushAwbStatus};
+use radcam_commands::{
+    Action as CameraAction, CameraControl,
+    protocol::display::base_display::{BaseAutoWhiteBalanceModeValue, BaseParameterSetting},
+};
+use tokio::task::JoinHandle;
+use tracing::*;
+use uuid::Uuid;
+
+use crate::web::{camera_state, camera_ui};
+
+/// Consecutive identical RGB samples required after movement before settle (Auto path).
+pub const STABLE_SAMPLES: u8 = 2;
+/// Wall-clock ceiling for a Running phase.
+pub const RUN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+/// How long clients keep WB controls disabled after settle.
+pub const COOLDOWN: std::time::Duration = std::time::Duration::from_secs(3);
+/// Poll interval while Running.
+pub const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RgbSample {
+    pub red: u8,
+    pub green: u8,
+    pub blue: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettleMachine {
+    start_rgb: Option<RgbSample>,
+    last_rgb: Option<RgbSample>,
+    saw_change: bool,
+    stable_count: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObserveResult {
+    Continue,
+    Settled,
+}
+
+struct TrackerEntry {
+    handle: JoinHandle<()>,
+}
+
+static TRACKERS: OnceCell<Mutex<HashMap<Uuid, TrackerEntry>>> = OnceCell::new();
+
+impl RgbSample {
+    pub fn from_base(base: &BaseParameterSetting) -> Option<Self> {
+        Some(Self {
+            red: base.awb_red?,
+            green: base.awb_green?,
+            blue: base.awb_blue?,
+        })
+    }
+}
+
+impl SettleMachine {
+    pub fn begin(start: &BaseParameterSetting) -> Self {
+        let rgb = RgbSample::from_base(start);
+        Self {
+            start_rgb: rgb,
+            last_rgb: rgb,
+            saw_change: false,
+            stable_count: 0,
+        }
+    }
+
+    /// Feed a base-parameter sample. Settles on Manual-after-change or RGB stability.
+    pub fn observe(&mut self, sample: &BaseParameterSetting) -> ObserveResult {
+        let rgb = RgbSample::from_base(sample);
+        if let Some(current) = rgb {
+            if let Some(last) = self.last_rgb {
+                if current != last {
+                    self.saw_change = true;
+                    self.stable_count = 0;
+                } else if self.saw_change {
+                    self.stable_count = self.stable_count.saturating_add(1);
+                }
+            }
+            if let Some(start) = self.start_rgb
+                && current != start
+            {
+                self.saw_change = true;
+            }
+            self.last_rgb = Some(current);
+        }
+
+        let manual = matches!(sample.auto_awb, Some(BaseAutoWhiteBalanceModeValue::Manual));
+
+        if self.saw_change && manual {
+            return ObserveResult::Settled;
+        }
+        if self.saw_change && self.stable_count >= STABLE_SAMPLES {
+            return ObserveResult::Settled;
+        }
+        ObserveResult::Continue
+    }
+}
+
+/// True while Running or Cooldown for this camera.
+pub(crate) fn is_busy(camera_uuid: Uuid) -> bool {
+    camera_ui::get(camera_uuid).one_push_awb.is_some()
+}
+
+/// True when `action` is a one-push AWB trigger.
+pub(crate) fn action_triggers_once_awb(action: &CameraAction) -> bool {
+    match action {
+        CameraAction::SetImageAdjustmentEx(params)
+        | CameraAction::SetImageAdjustmentExAll(params) => params.once_awb == Some(1),
+        _ => false,
+    }
+}
+
+/// Abort the poll task and clear UI phase (camera gone / pruned).
+#[instrument(level = "debug")]
+pub(crate) fn abort(camera_uuid: Uuid) {
+    if let Some(entry) = trackers().lock().unwrap().remove(&camera_uuid) {
+        entry.handle.abort();
+    }
+    camera_ui::set_one_push_awb(camera_uuid, None);
+}
+
+/// Abort every tracker whose camera is no longer known.
+#[instrument(level = "debug", skip_all)]
+pub(crate) fn retain_known_cameras(known: &std::collections::HashSet<Uuid>) {
+    let stale: Vec<Uuid> = {
+        let lock = trackers().lock().unwrap();
+        lock.keys()
+            .copied()
+            .filter(|uuid| !known.contains(uuid))
+            .collect()
+    };
+    for uuid in stale {
+        abort(uuid);
+    }
+}
+
+/// Start Running after a successful onceAWB SET, or no-op if already busy.
+#[instrument(level = "debug")]
+pub(crate) fn begin_after_trigger(camera_uuid: Uuid) {
+    if is_busy(camera_uuid) {
+        return;
+    }
+
+    {
+        let mut lock = trackers().lock().unwrap();
+        if let Some(entry) = lock.remove(&camera_uuid) {
+            entry.handle.abort();
+        }
+    }
+
+    camera_ui::set_one_push_awb(
+        camera_uuid,
+        Some(OnePushAwbStatus {
+            phase: OnePushAwbPhase::Running,
+        }),
+    );
+
+    let handle = tokio::spawn(run_tracker(camera_uuid).instrument(Span::current()));
+    trackers()
+        .lock()
+        .unwrap()
+        .insert(camera_uuid, TrackerEntry { handle });
+}
+
+/// After a successful control that included onceAWB, start trackers.
+#[instrument(level = "debug", skip_all, fields(%camera_uuid))]
+pub(crate) fn on_control_success(camera_uuid: Uuid, action: &CameraAction) {
+    if !action_triggers_once_awb(action) {
+        return;
+    }
+
+    match action {
+        CameraAction::SetImageAdjustmentEx(_) => {
+            begin_after_trigger(camera_uuid);
+        }
+        CameraAction::SetImageAdjustmentExAll(_) => {
+            let span = Span::current();
+            tokio::spawn(
+                async move {
+                    let cameras = mcm_client::cameras().await;
+                    for uuid in cameras.keys().copied() {
+                        begin_after_trigger(uuid);
+                    }
+                }
+                .instrument(span),
+            );
+        }
+        _ => {}
+    }
+}
+
+fn trackers() -> &'static Mutex<HashMap<Uuid, TrackerEntry>> {
+    TRACKERS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+#[instrument(level = "debug", skip_all, fields(%camera_uuid))]
+async fn run_tracker(camera_uuid: Uuid) {
+    let start = Instant::now();
+    let initial = match fetch_base_setting(camera_uuid).await {
+        Ok(base) => base,
+        Err(error) => {
+            warn!("one-push AWB start snapshot failed: {error}");
+            finish_timeout(camera_uuid);
+            return;
+        }
+    };
+
+    // Push the start snapshot so clients see gains as soon as the run begins.
+    if let Ok(value) = serde_json::to_value(&initial) {
+        camera_state::emit(CameraStateEvent {
+            camera_uuid,
+            base_parameters: Some(value),
+            ..Default::default()
+        });
+    }
+
+    let mut machine = SettleMachine::begin(&initial);
+    let mut last_emitted = initial.clone();
+
+    loop {
+        tokio::time::sleep(POLL_INTERVAL).await;
+
+        if start.elapsed() >= RUN_TIMEOUT {
+            finish_timeout(camera_uuid);
+            return;
+        }
+
+        let sample = match fetch_base_setting(camera_uuid).await {
+            Ok(base) => base,
+            Err(error) => {
+                warn!("one-push AWB poll failed: {error}");
+                continue;
+            }
+        };
+
+        if sample != last_emitted
+            && let Ok(value) = serde_json::to_value(&sample)
+        {
+            camera_state::emit(CameraStateEvent {
+                camera_uuid,
+                base_parameters: Some(value),
+                ..Default::default()
+            });
+            last_emitted = sample.clone();
+        }
+
+        if machine.observe(&sample) == ObserveResult::Settled {
+            finish_settled(camera_uuid).await;
+            return;
+        }
+    }
+}
+
+async fn finish_settled(camera_uuid: Uuid) {
+    camera_ui::set_one_push_awb(
+        camera_uuid,
+        Some(OnePushAwbStatus {
+            phase: OnePushAwbPhase::Cooldown,
+        }),
+    );
+    tokio::time::sleep(COOLDOWN).await;
+    // Only clear if we are still the cooldown owner (no newer run).
+    if matches!(
+        camera_ui::get(camera_uuid)
+            .one_push_awb
+            .as_ref()
+            .map(|status| status.phase),
+        Some(OnePushAwbPhase::Cooldown)
+    ) {
+        camera_ui::set_one_push_awb(camera_uuid, None);
+    }
+    trackers().lock().unwrap().remove(&camera_uuid);
+}
+
+fn finish_timeout(camera_uuid: Uuid) {
+    camera_ui::set_warning(camera_uuid, "One-push white balance timed out".to_string());
+    camera_ui::set_one_push_awb(camera_uuid, None);
+    trackers().lock().unwrap().remove(&camera_uuid);
+}
+
+async fn fetch_base_setting(camera_uuid: Uuid) -> Result<BaseParameterSetting, String> {
+    let value = radcam_commands::handle_control(CameraControl {
+        camera_uuid,
+        action: CameraAction::GetImageAdjustment,
+    })
+    .await
+    .map_err(|error| format!("{error:?}"))?;
+    serde_json::from_value(value).map_err(|error| error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base(r: u8, g: u8, b: u8, manual: bool) -> BaseParameterSetting {
+        BaseParameterSetting {
+            awb_red: Some(r),
+            awb_green: Some(g),
+            awb_blue: Some(b),
+            auto_awb: Some(if manual {
+                BaseAutoWhiteBalanceModeValue::Manual
+            } else {
+                BaseAutoWhiteBalanceModeValue::Auto
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn manual_after_rgb_change_settles() {
+        let start = base(10, 20, 30, false);
+        let mut machine = SettleMachine::begin(&start);
+        assert_eq!(
+            machine.observe(&base(11, 20, 30, false)),
+            ObserveResult::Continue
+        );
+        assert_eq!(
+            machine.observe(&base(11, 20, 30, true)),
+            ObserveResult::Settled
+        );
+    }
+
+    #[test]
+    fn already_manual_settles_on_first_rgb_change() {
+        let start = base(10, 20, 30, true);
+        let mut machine = SettleMachine::begin(&start);
+        assert_eq!(
+            machine.observe(&base(40, 20, 30, true)),
+            ObserveResult::Settled
+        );
+    }
+
+    #[test]
+    fn auto_settles_on_rgb_stability() {
+        let start = base(10, 20, 30, false);
+        let mut machine = SettleMachine::begin(&start);
+        assert_eq!(
+            machine.observe(&base(40, 20, 30, false)),
+            ObserveResult::Continue
+        );
+        assert_eq!(
+            machine.observe(&base(40, 20, 30, false)),
+            ObserveResult::Continue
+        );
+        assert_eq!(
+            machine.observe(&base(40, 20, 30, false)),
+            ObserveResult::Settled
+        );
+    }
+
+    #[test]
+    fn no_change_never_settles() {
+        let start = base(10, 20, 30, true);
+        let mut machine = SettleMachine::begin(&start);
+        for _ in 0..5 {
+            assert_eq!(
+                machine.observe(&base(10, 20, 30, true)),
+                ObserveResult::Continue
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Split from the websockets work: **Backend-owned one-push AWB lifecycle and settle**.

Commits in this slice:
- `backend: libs: radcam_manager: Own one-push AWB lifecycle`
- `backend: libs: radcam_manager: Harden one-push AWB settle against premature finish`

## Stack
- Part **23/24** of the websockets split (all PRs target `master`)
- Depends on https://github.com/bluerobotics/radcam-manager/pull/223 merging first.
- After the previous stack PR merges: rebase this branch onto `master` and `git push --force-with-lease`
- Intermediate slices may show **red CI** (incomplete stack / missing later fixes). That is expected.
- The batch is only done when tip **[#225](https://github.com/bluerobotics/radcam-manager/pull/225)** (`24/24`) is green after the full merge-rebase dance.

## Test plan
- [ ] Triggering onceAWB sets shared Running, then clears only after Manual + stable RGB (or timeout)
- [ ] Concurrent onceAWB while busy is a no-op success (does not restart the run)
- [ ] Opening snapshot fetch failures retry instead of instantly clearing the busy overlay
- [ ] All subscribed clients see the same `one_push_awb` phase
