### PR TITLE
websockets 24/24: Drive one-push WB UI from shared camera UI state

### DIFF
--- a/frontend/src/components/BasicSettings.vue
+++ b/frontend/src/components/BasicSettings.vue
@@ -7,14 +7,14 @@
     >
       <BlueButtonGroup
         label="Water environment White Balance"
-        :disabled="!isConfigured || props.disabled || processingWhiteBalance"
+        :disabled="!isConfigured || props.disabled || wbBusy"
         :button-items="WhiteBalanceSceneButtonItems"
         theme="dark"
         type="switch"
       />
       <BlueButtonGroup
         label="White Balance Mode"
-        :disabled="!isConfigured || props.disabled || processingWhiteBalance"
+        :disabled="!isConfigured || props.disabled || wbBusy"
         :button-items="whiteBalanceModeButtonItems"
         theme="dark"
         type="switch"
@@ -24,7 +24,7 @@
         class="d-flex flex-col align-end mt-6"
       >
         <v-btn
-          :disabled="props.disabled"
+          :disabled="props.disabled || wbBusy"
           class="py-1 px-3 ml-4 rounded-md bg-[#414141] hover:bg-[#0A3E6B]"
           size="small"
           variant="elevated"
@@ -32,13 +32,13 @@
           @click="doWhiteBalance"
         >
           <v-progress-circular
-            v-if="processingWhiteBalance"
+            v-if="wbRunning"
             indeterminate
             color="white"
             size="20"
             class="me-2"
           />
-          {{ processingWhiteBalance ? "Processing..." : "One-Push White Balance" }}
+          {{ onePushLabel }}
         </v-btn>
       </div>
       <div
@@ -47,7 +47,7 @@
       >
         <BlueSlider
           v-model="baseParams.awb_red"
-          :disabled="!isConfigured || props.disabled || processingWhiteBalance"
+          :disabled="!isConfigured || props.disabled || wbBusy"
           name="red"
           label="Red"
           :min="0"
@@ -60,7 +60,7 @@
         />
         <BlueSlider
           v-model="baseParams.awb_blue"
-          :disabled="!isConfigured || props.disabled || processingWhiteBalance"
+          :disabled="!isConfigured || props.disabled || wbBusy"
           name="blue"
           label="Blue"
           :min="0"
@@ -175,7 +175,7 @@
     >
       <BlueSelect
         v-model="selectedVideoResolution"
-        :disabled="!isConfigured || props.disabled || processingWhiteBalance"
+        :disabled="!isConfigured || props.disabled"
         label="Resolution"
         :items="resolutionOptions || [{ name: 'No resolutions available', value: null }]"
         theme="dark"
@@ -183,7 +183,7 @@
       />
       <BlueSelect
         v-model="selectedVideoBitrate"
-        :disabled="!isConfigured || props.disabled || processingWhiteBalance"
+        :disabled="!isConfigured || props.disabled"
         label="Bitrate"
         :items="bitrateOptions || [{ name: 'No bitrates available', value: null }]"
         theme="dark"
@@ -264,7 +264,7 @@
         class="flex justify-end mt-8 mb-[-20px]"
       >
         <v-btn
-          :disabled="!isConfigured || props.disabled || processingWhiteBalance"
+          :disabled="!isConfigured || props.disabled"
           class="py-1 px-3 rounded-md bg-[#0B5087] hover:bg-[#0A3E6B]"
           :class="{ 'opacity-50 pointer-events-none': !hasUnsavedVideoChanges }"
           size="small"
@@ -316,7 +316,7 @@
             class="py-1 px-3 ml-4 rounded-md bg-[#0B5087] hover:bg-[#0A3E6B]"
             size="small"
             variant="elevated"
-            :disabled="props.disabled || processingWhiteBalance"
+            :disabled="props.disabled"
             :loading="props.loading"
             theme="dark"
             @click="resetToRecommendedDefaults"
@@ -618,7 +618,7 @@
             class="py-1 px-3 ml-4 rounded-md bg-[#0B5087] hover:bg-[#0A3E6B]"
             size="small"
             variant="elevated"
-            :disabled="hasChannelErrors || props.disabled || processingWhiteBalance"
+            :disabled="hasChannelErrors || props.disabled"
             :loading="props.loading"
             theme="dark"
             @click="saveHardwareSetup"
@@ -654,7 +654,7 @@ import {
 import { createPendingFields } from '@/utils/pendingFields'
 import { useCameraState } from '@/utils/useCameraState'
 import type { ActuatorsConfig, ActuatorsControl, ActuatorsParametersConfig, ActuatorsState, CameraID, MountType, ScriptFunction, ServoChannel } from '@/bindings/autopilot'
-import type { CameraStateEvent } from '@/bindings/radcam_api'
+import type { CameraStateEvent, OnePushAwbStatus } from '@/bindings/radcam_api'
 import WelcomeDialog from './WelcomeDialog.vue'
 
 
@@ -663,7 +663,16 @@ const props = defineProps<{
   disabled: boolean
   loading: boolean
   cockpitMode: boolean
+  onePushAwb?: OnePushAwbStatus | null
 }>()
+
+const wbBusy = computed(() => props.onePushAwb != null)
+const wbRunning = computed(() => props.onePushAwb?.phase === 'running')
+const onePushLabel = computed(() => {
+  if (props.onePushAwb?.phase === 'running') return 'Processing...'
+  if (props.onePushAwb?.phase === 'cooldown') return 'Cooling down...'
+  return 'One-Push White Balance'
+})
 
 interface ServoChannelOption {
   name: string
@@ -874,7 +883,6 @@ const defaultFocusAndZoomParams = ref<ActuatorsParametersConfig>({
   tilt_mnt_pitch_max: null,
 })
 const hasUnsavedVideoChanges = ref<boolean>(false)
-const processingWhiteBalance = ref(false)
 
 watch(
   () => props.selectedCameraUuid,
@@ -886,7 +894,6 @@ watch(
     correlationLatch.value = null
     isConfigured.value = false
     showAdvancedHardware.value = false
-    processingWhiteBalance.value = false
     const emptyParams: ActuatorsParametersConfig = {
       camera_id: null,
       focus_channel: null,
@@ -1559,16 +1566,11 @@ const update_video_parameter_values = (settings: VideoParameterSettings) => {
 }
 
 const doWhiteBalance = async () => {
-  if (!props.selectedCameraUuid || props.disabled) {
+  if (!props.selectedCameraUuid || props.disabled || wbBusy.value) {
     return
   }
 
-  // Prevent multiple concurrent white balance operations
-  if (processingWhiteBalance.value) return
-  processingWhiteBalance.value = true
-
   const cameraUuid = props.selectedCameraUuid
-  const generation = actuatorsRequestGeneration.value
   const payload: CameraControl = {
     camera_uuid: cameraUuid,
     action: "setImageAdjustmentEx",
@@ -1580,12 +1582,6 @@ const doWhiteBalance = async () => {
   backendClient.request('POST', '/camera/control', payload)
     .catch(error => {
       console.error("Error sending onceAWB control:", error.message)
-    }).finally(() => {
-      if (generation !== actuatorsRequestGeneration.value) return
-      processingWhiteBalance.value = false
-      if (props.selectedCameraUuid === cameraUuid) {
-        getBaseParameters()
-      }
     })
 }
 

--- a/frontend/src/components/BasicSettings.vue
+++ b/frontend/src/components/BasicSettings.vue
@@ -32,7 +32,7 @@
           @click="doWhiteBalance"
         >
           <v-progress-circular
-            v-if="wbRunning"
+            v-if="wbBusy"
             indeterminate
             color="white"
             size="20"
@@ -667,10 +667,8 @@ const props = defineProps<{
 }>()
 
 const wbBusy = computed(() => props.onePushAwb != null)
-const wbRunning = computed(() => props.onePushAwb?.phase === 'running')
 const onePushLabel = computed(() => {
-  if (props.onePushAwb?.phase === 'running') return 'Processing...'
-  if (props.onePushAwb?.phase === 'cooldown') return 'Cooling down...'
+  if (props.onePushAwb != null) return 'Processing...'
   return 'One-Push White Balance'
 })
 

--- a/frontend/src/components/ImageTab.vue
+++ b/frontend/src/components/ImageTab.vue
@@ -92,17 +92,17 @@
     <div class="ma-2 text-right">
       <v-btn
         variant="tonal"
-        :disabled="props.disabled || processingWhiteBalance"
+        :disabled="props.disabled || wbBusy"
         @click="doWhiteBalance"
       >
         <v-progress-circular
-          v-if="processingWhiteBalance"
+          v-if="wbRunning"
           indeterminate
           color="white"
           size="20"
           class="me-2"
         />
-        {{ processingWhiteBalance ? "Processing..." : "One-Push White Balance" }}
+        {{ onePushLabel }}
       </v-btn>
     </div>
   </div>
@@ -118,7 +118,7 @@
           :model-value="baseParams.auto_awb"
           :items="autoWhiteBalanceModeOptions"
           label="White Balance Mode"
-          :disabled="props.disabled"
+          :disabled="props.disabled || wbBusy"
           item-title="text"
           item-value="value"
           class="mb-4"
@@ -129,7 +129,7 @@
           :model-value="baseParams.awb_auto_mode"
           :items="autoWhiteBalanceSceneOptions"
           label="White Balance Scene"
-          :disabled="props.disabled"
+          :disabled="props.disabled || wbBusy"
           item-title="text"
           item-value="value"
           class="mb-4"
@@ -145,7 +145,7 @@
             :min="0"
             :max="255"
             :step="1"
-            :disabled="props.disabled"
+            :disabled="props.disabled || wbBusy"
             @update:current="updateBaseParameter('awb_red', $event)"
           />
           <Slider
@@ -155,7 +155,7 @@
             :min="0"
             :max="255"
             :step="1"
-            :disabled="props.disabled"
+            :disabled="props.disabled || wbBusy"
             @update:current="updateBaseParameter('awb_green', $event)"
           />
           <Slider
@@ -165,7 +165,7 @@
             :min="0"
             :max="255"
             :step="1"
-            :disabled="props.disabled"
+            :disabled="props.disabled || wbBusy"
             @update:current="updateBaseParameter('awb_blue', $event)"
           />
         </div>
@@ -176,7 +176,7 @@
           :min="0"
           :max="255"
           :step="1"
-          :disabled="props.disabled"
+          :disabled="props.disabled || wbBusy"
           @update:current="updateBaseParameter('awb_style_red', $event)"
         />
         <Slider
@@ -186,7 +186,7 @@
           :min="0"
           :max="255"
           :step="1"
-          :disabled="props.disabled"
+          :disabled="props.disabled || wbBusy"
           @update:current="updateBaseParameter('awb_style_green', $event)"
         />
         <Slider
@@ -196,7 +196,7 @@
           :min="0"
           :max="255"
           :step="1"
-          :disabled="props.disabled"
+          :disabled="props.disabled || wbBusy"
           @update:current="updateBaseParameter('awb_style_blue', $event)"
         />
       </v-expansion-panel-text>
@@ -731,14 +731,23 @@ import { enumToOptions } from '@/utils/enumUtils'
 import { backendClient } from '@/utils/backendClient'
 import { useCameraState } from '@/utils/useCameraState'
 import { createPendingFields } from '@/utils/pendingFields'
-import { ref, toRef, watch } from 'vue'
+import type { OnePushAwbStatus } from '@/bindings/radcam_api'
+import { computed, ref, toRef, watch } from 'vue'
 
 const props = defineProps<{
   selectedCameraUuid: string | null
   disabled: boolean
+  onePushAwb?: OnePushAwbStatus | null
 }>()
 
-const processingWhiteBalance = ref(false)
+const wbBusy = computed(() => props.onePushAwb != null)
+const wbRunning = computed(() => props.onePushAwb?.phase === 'running')
+const onePushLabel = computed(() => {
+  if (props.onePushAwb?.phase === 'running') return 'Processing...'
+  if (props.onePushAwb?.phase === 'cooldown') return 'Cooling down...'
+  return 'One-Push White Balance'
+})
+
 const processingBaseRestore = ref(false)
 const processingAdvancedRestore = ref(false)
 
@@ -880,7 +889,6 @@ watch(
     imageRequestGeneration.value += 1
     pendingBase.clear()
     pendingAdvanced.clear()
-    processingWhiteBalance.value = false
     processingBaseRestore.value = false
     processingAdvancedRestore.value = false
   },
@@ -972,18 +980,12 @@ const getBaseParameters = () => {
 }
 
 const doWhiteBalance = async () => {
-  if (!props.selectedCameraUuid) {
+  if (!props.selectedCameraUuid || props.disabled || wbBusy.value) {
     return
   }
 
-  // Prevent multiple concurrent white balance operations
-  if (processingWhiteBalance.value) return
-  processingWhiteBalance.value = true
-
-  const cameraUuid = props.selectedCameraUuid
-  const generation = imageRequestGeneration.value
   const payload: CameraControl = {
-    camera_uuid: cameraUuid,
+    camera_uuid: props.selectedCameraUuid,
     action: "setImageAdjustmentEx",
     json: {
       onceAWB: 1,
@@ -993,12 +995,6 @@ const doWhiteBalance = async () => {
   backendClient.request('POST', '/camera/control', payload)
     .catch(error => {
       console.error("Error sending onceAWB control:", error.message)
-    }).finally(() => {
-      if (generation !== imageRequestGeneration.value) return
-      processingWhiteBalance.value = false
-      if (props.selectedCameraUuid === cameraUuid) {
-        getBaseParameters()
-      }
     })
 }
 

--- a/frontend/src/components/ImageTab.vue
+++ b/frontend/src/components/ImageTab.vue
@@ -96,7 +96,7 @@
         @click="doWhiteBalance"
       >
         <v-progress-circular
-          v-if="wbRunning"
+          v-if="wbBusy"
           indeterminate
           color="white"
           size="20"
@@ -741,10 +741,8 @@ const props = defineProps<{
 }>()
 
 const wbBusy = computed(() => props.onePushAwb != null)
-const wbRunning = computed(() => props.onePushAwb?.phase === 'running')
 const onePushLabel = computed(() => {
-  if (props.onePushAwb?.phase === 'running') return 'Processing...'
-  if (props.onePushAwb?.phase === 'cooldown') return 'Cooling down...'
+  if (props.onePushAwb != null) return 'Processing...'
   return 'One-Push White Balance'
 })
 

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -148,6 +148,7 @@
             :disabled="!backendConnected || selectedCameraUUID == null || uiLoading || uiRebooting"
             :loading="uiLoading"
             :cockpit-mode="isCockpitMode"
+            :one-push-awb="onePushAwb"
           />
         </div>
         <div v-if="configMode === 'advanced'">
@@ -175,6 +176,7 @@
               <ImageTab
                 :selected-camera-uuid="selectedCameraUUID"
                 :disabled="!backendConnected || selectedCameraUUID == null || uiLoading || uiRebooting"
+                :one-push-awb="onePushAwb"
               />
             </v-tabs-window-item>
             <v-tabs-window-item value="streams">
@@ -203,7 +205,7 @@ import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRouteQuery } from '@vueuse/router'
 
 import type { Camera } from '@/bindings/mcm_client'
-import type { CameraStateEvent, CameraUiState } from '@/bindings/radcam_api'
+import type { CameraStateEvent, CameraUiState, OnePushAwbStatus } from '@/bindings/radcam_api'
 import BasicSettings from '@/components/BasicSettings.vue'
 import BlueButtonGroup from '@/components/BlueButtonGroup.vue'
 import ImageTab from '@/components/ImageTab.vue'
@@ -283,6 +285,7 @@ const cameraControls = ref<InstanceType<typeof BasicSettings> | null>(null)
 const uiLoading = ref(false)
 const uiLoadingMessage = ref('Applying settings…')
 const uiRebooting = ref(false)
+const onePushAwb = ref<OnePushAwbStatus | null>(null)
 const errorDialogMessage = ref<string | null>(null)
 const warningToastMessage = ref<string | null>(null)
 const isCockpitMode = useRouteQuery<string, boolean>('cockpit_mode', 'false', {
@@ -314,6 +317,7 @@ const applyCameraUi = (ui: CameraUiState) => {
     uiLoadingMessage.value = ui.loading_message
   }
   uiRebooting.value = ui.rebooting
+  onePushAwb.value = ui.one_push_awb ?? null
   errorDialogMessage.value = ui.error_dialog ?? null
   warningToastMessage.value = ui.warning_toast ?? null
 }
@@ -339,6 +343,7 @@ watch(selectedCameraUUID, (uuid, previousUuid) => {
   if (!uuid) {
     uiLoading.value = false
     uiRebooting.value = false
+    onePushAwb.value = null
     errorDialogMessage.value = null
     warningToastMessage.value = null
     return
@@ -358,6 +363,7 @@ watch(selectedCameraUUID, (uuid, previousUuid) => {
   } else {
     uiLoading.value = false
     uiRebooting.value = false
+    onePushAwb.value = null
     errorDialogMessage.value = null
     warningToastMessage.value = null
   }


### PR DESCRIPTION
## Summary
Split from the websockets work: **Drive one-push WB UI from shared camera UI state**.

Commits in this slice:
- `frontend: Drive one-push WB UI from shared camera UI state`
- `frontend: Keep Processing label during one-push AWB cooldown`

## Stack
- Part **24/24** of the websockets split (all PRs target `master`)
- Depends on https://github.com/bluerobotics/radcam-manager/pull/224 merging first.
- After the previous stack PR merges: rebase this branch onto `master` and `git push --force-with-lease`

## Test plan
- [ ] CI green on this branch
- [ ] Diff vs `master` matches only this slice once prior stack PRs are on `master`
